### PR TITLE
Add network speed measurement feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ pip install -r requirements.txt
   - 代表的なポートへの接続可否
   - SSL 証明書の発行者と有効期限
   - DNS の SPF レコード
+  - ネットワーク速度測定 (download/upload/ping)
   - これらを基にしたセキュリティスコア（0〜10）
 
 この最小構成を起点に、今後の機能追加を行っていきます。
@@ -162,6 +163,21 @@ python firewall_check.py
 ```
 
 Windows 以外の環境では `defender_enabled` が `null` となります。
+
+## ネットワーク速度測定
+
+`network_speed.py` は `speedtest-cli` を利用してダウンロード速度、アップロード速度、
+および ping を計測します。
+
+```bash
+python network_speed.py
+```
+
+出力例:
+
+```json
+{"download": 100.0, "upload": 20.0, "ping": 15.0}
+```
 
 ## LANセキュリティ診断
 

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -62,6 +62,14 @@ class SecurityReport {
   });
 }
 
+class NetworkSpeed {
+  final double downloadMbps;
+  final double uploadMbps;
+  final double pingMs;
+
+  const NetworkSpeed(this.downloadMbps, this.uploadMbps, this.pingMs);
+}
+
 /// Runs the system ping command.
 Future<String> runPing([String host = 'google.com']) async {
   final args = Platform.isWindows ? ['-n', '4', host] : ['-c', '4', host];
@@ -70,6 +78,24 @@ Future<String> runPing([String host = 'google.com']) async {
     return result.stdout.toString();
   } catch (e) {
     return 'Failed to run ping: $e';
+  }
+}
+
+/// Measures network speed using the `network_speed.py` script.
+Future<NetworkSpeed?> measureNetworkSpeed() async {
+  const script = 'network_speed.py';
+  try {
+    final result = await Process.run('python', [script]);
+    if (result.exitCode != 0) {
+      return null;
+    }
+    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final down = (data['download'] as num).toDouble();
+    final up = (data['upload'] as num).toDouble();
+    final ping = (data['ping'] as num).toDouble();
+    return NetworkSpeed(down, up, ping);
+  } catch (_) {
+    return null;
   }
 }
 

--- a/network_speed.py
+++ b/network_speed.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Measure network speed using speedtest-cli."""
+import json
+try:
+    import speedtest
+except ImportError:  # pragma: no cover - handled in tests
+    speedtest = None
+
+
+def measure_speed() -> dict[str, float]:
+    if speedtest is None:
+        raise RuntimeError("speedtest module not available")
+    st = speedtest.Speedtest()
+    st.get_best_server()
+    download = st.download()
+    upload = st.upload()
+    ping = st.results.ping
+    return {
+        "download": download / 1e6,  # Mbps
+        "upload": upload / 1e6,
+        "ping": float(ping),
+    }
+
+
+def main() -> None:
+    data = measure_speed()
+    print(json.dumps(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ geoip2
 psutil
 pdfkit
 weasyprint
+
+speedtest-cli

--- a/test/test_network_speed.py
+++ b/test/test_network_speed.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import importlib
+import network_speed
+
+class NetworkSpeedTest(unittest.TestCase):
+    @patch.object(network_speed, 'speedtest')
+    def test_measure_speed(self, mock_speedtest):
+        MockSpeedtest = MagicMock()
+        mock_speedtest.Speedtest = MockSpeedtest
+        inst = MockSpeedtest.return_value
+        inst.download.return_value = 100_000_000
+        inst.upload.return_value = 20_000_000
+        inst.results = MagicMock(ping=15.0)
+        inst.get_best_server.return_value = {}
+        result = network_speed.measure_speed()
+        self.assertAlmostEqual(result['download'], 100.0)
+        self.assertAlmostEqual(result['upload'], 20.0)
+        self.assertEqual(result['ping'], 15.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `speedtest-cli` dependency
- implement `network_speed.py` script
- expose `measureNetworkSpeed()` from diagnostics library
- document speed test usage in README
- test network speed helper

## Testing
- `python -m unittest discover -s test`


------
https://chatgpt.com/codex/tasks/task_e_6867529d4bd88323820922d1456da03d