### PR TITLE
Improve LAN scan error handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,12 @@ class _HomePageState extends State<HomePage> {
       _output = '診断中...\n';
     });
 
-    final devices = await net.scanNetwork();
+    final devices = await net.scanNetwork(onError: (msg) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('LANスキャン失敗: $msg')));
+      }
+    });
     setState(() {
       _devices = devices;
     });

--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -12,12 +12,15 @@ class NetworkDevice {
 }
 
 /// Runs the LAN discovery script and returns a list of devices.
-Future<List<NetworkDevice>> scanNetwork() async {
+Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}) async {
   const script = 'discover_hosts.py';
   try {
     final result = await Process.run('python', [script]);
     if (result.exitCode != 0) {
-      throw result.stderr.toString();
+      final msg = result.stderr.toString();
+      print(msg);
+      if (onError != null) onError(msg);
+      return [];
     }
     final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
     final devices = <NetworkDevice>[];
@@ -31,7 +34,9 @@ Future<List<NetworkDevice>> scanNetwork() async {
       }
     }
     return devices;
-  } catch (_) {
+  } catch (e) {
+    print(e);
+    if (onError != null) onError(e.toString());
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- surface LAN scan errors via console and optional callback
- notify the user when LAN scan fails

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc543a9883239004b08d838eeba4