### PR TITLE
Switch to file_selector

### DIFF
--- a/.flutter-plugins
+++ b/.flutter-plugins
@@ -1,5 +1,4 @@
 # This is a generated file; do not edit or check into version control.
-file_picker=C:\\Users\\Komiya Yusuke\\AppData\\Local\\Pub\\Cache\\hosted\\pub.dev\\file_picker-6.2.1\\
 file_selector=C:\\Users\\Komiya Yusuke\\AppData\\Local\\Pub\\Cache\\hosted\\pub.dev\\file_selector-1.0.3\\
 file_selector_android=C:\\Users\\Komiya Yusuke\\AppData\\Local\\Pub\\Cache\\hosted\\pub.dev\\file_selector_android-0.5.1+14\\
 file_selector_ios=C:\\Users\\Komiya Yusuke\\AppData\\Local\\Pub\\Cache\\hosted\\pub.dev\\file_selector_ios-0.5.3+1\\

--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -1,4 +1,4 @@
-import 'package:file_picker/file_picker.dart';
+import 'package:file_selector/file_selector.dart' as fs;
 import 'package:path/path.dart' as p;
 import 'dart:io';
 
@@ -8,11 +8,8 @@ import 'dart:io';
 /// to the user in the dialog.
 Future<String?> getSavePath({String suggestedName = 'report.txt'}) async {
   try {
-    final path = await FilePicker.platform.saveFile(
-      dialogTitle: 'Save Report',
-      fileName: suggestedName,
-    );
-    return path;
+    final location = await fs.getSaveLocation(suggestedName: suggestedName);
+    return location?.path;
   } catch (e) {
     return null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ dependencies:
   flutter:
     sdk: flutter
   file_selector: ^1.0.0
-  file_picker: ^6.1.1
   path: any
   http: ^1.4.0
   fl_chart: ^0.63.0


### PR DESCRIPTION
## Summary
- drop `file_picker` dependency
- use `file_selector`'s save dialog in `file_utils`
- remove generated plugin data for `file_picker`

## Testing
- `flutter pub get` *(fails: command not found)*
- `pytest -q` *(fails to import project modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc4652288323b52a3f58fe1a1338