### PR TITLE
Fix vendor lookup path

### DIFF
--- a/discover_hosts.py
+++ b/discover_hosts.py
@@ -99,7 +99,7 @@ def _run_nmap_scan(subnet):
 
 def _lookup_vendor(mac):
     prefix = mac.upper().replace(':', '')[:6]
-    db_path = Path('oui.txt')
+    db_path = Path(__file__).with_name('oui.txt')
     if db_path.exists():
         try:
             with db_path.open('r', encoding='utf-8', errors='ignore') as f:


### PR DESCRIPTION
## Summary
- ensure `_lookup_vendor` reads `oui.txt` relative to the script

## Testing
- `python -m unittest discover -s test`


------
https://chatgpt.com/codex/tasks/task_e_6867de7c4e688323832454375638aab3