### PR TITLE
Fix save dialog call

### DIFF
--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -8,8 +8,8 @@ import 'dart:io';
 /// to the user in the dialog.
 Future<String?> getSavePath({String suggestedName = 'report.txt'}) async {
   try {
-    final path = await fs.getSavePath(suggestedName: suggestedName);
-    return path;
+    final loc = await fs.getSaveLocation(suggestedName: suggestedName);
+    return loc?.path;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Summary
- update file save API usage in `file_utils.dart`

## Testing
- `dart format lib/utils/file_utils.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688db329c883239c56d18e3226cc7c