### PR TITLE
Fix file save dialog

### DIFF
--- a/lib/utils/file_utils.dart
+++ b/lib/utils/file_utils.dart
@@ -8,7 +8,12 @@ import 'dart:io';
 /// to the user in the dialog.
 Future<String?> getSavePath({String suggestedName = 'report.txt'}) async {
   try {
-    final loc = await fs.getSaveLocation(suggestedName: suggestedName);
+    final loc = await fs.getSaveLocation(
+      suggestedName: suggestedName,
+      acceptedTypeGroups: const [
+        fs.XTypeGroup(label: 'text', extensions: ['txt'])
+      ],
+    );
     return loc?.path;
   } catch (e) {
     return null;


### PR DESCRIPTION
## Summary
- use `getSaveLocation` with file type filtering

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688fcfa7888323b598a27b0eecc489