### PR TITLE
Remove unused constant in risk_score

### DIFF
--- a/risk_score.py
+++ b/risk_score.py
@@ -6,9 +6,6 @@ import sys
 from common_constants import DANGER_COUNTRIES, SAFE_COUNTRIES
 
 
-# Weight factor for converting raw country points to the 0--4 range.
-COUNTRY_SCORE_WEIGHT = 1 / 12.5
-
 # Score added when encountering an unknown port.
 # Unknown services still add a small amount of risk.
 UNKNOWN_PORT_POINTS = 0.5


### PR DESCRIPTION
## Summary
- delete the unused `COUNTRY_SCORE_WEIGHT` constant in `risk_score.py`
- ensure unit tests continue to pass

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b866258c8323a26914078baed2ed