### PR TITLE
Implement enhanced nmap scan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ pip install -r requirements.txt
 
 
 `port_scan.py` スクリプトでは `nmap` を利用して指定したポート、またはポート指定が
-ない場合は全ポート (`-p-`) を自動的にスキャンし、結果を JSON 形式で出力します。LAN
-スキャン機能で各ホストの診断に使われるほか、次のように単体でも実行できます。
+ない場合は全ポート (`-p-`) をスキャンし、結果を JSON 形式で出力します。`-sV` による
+サービスバージョン検出や `-O` による OS 推定、さらに任意の NSE スクリプトを指定でき
+るようになりました。LAN スキャン機能で各ホストの診断に使われるほか、次のように単体
+でも実行できます。
 
 ```bash
-python port_scan.py <host> [port_list]
+python port_scan.py <host> [port_list] [--service] [--os] [--script vuln]
 ```
 
 ## LAN デバイス一覧取得
@@ -83,7 +85,7 @@ nmap -V # または arp-scan --version
 `lan_port_scan.py` は上記 2 つの機能を組み合わせ、LAN 内の各ホストを自動で検出した後、指定したポート (未指定時は主要ポート) をスキャンします。次のように実行します。
 
 ```bash
-python lan_port_scan.py --subnet 192.168.1.0/24 --ports 22,80
+python lan_port_scan.py --subnet 192.168.1.0/24 --ports 22,80 --service --os
 ```
 
 出力例:

--- a/port_scan.py
+++ b/port_scan.py
@@ -5,11 +5,24 @@ import subprocess
 import xml.etree.ElementTree as ET
 
 
-def run_scan(host: str, ports: list[str] | None = None) -> list[dict[str, str]]:
+def run_scan(
+    host: str,
+    ports: list[str] | None = None,
+    service: bool = False,
+    os_detect: bool = False,
+    scripts: list[str] | None = None,
+) -> list[dict[str, str]]:
+    cmd = ["nmap"]
+    if service:
+        cmd.append("-sV")
+    if os_detect:
+        cmd.append("-O")
+    if scripts:
+        cmd += ["--script", ",".join(scripts)]
     if not ports:
-        cmd = ["nmap", "-p-", "-oX", "-", host]
+        cmd += ["-p-", "-oX", "-", host]
     else:
-        cmd = ["nmap", "-p", ",".join(ports), "-oX", "-", host]
+        cmd += ["-p", ",".join(ports), "-oX", "-", host]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip())
@@ -21,19 +34,41 @@ def run_scan(host: str, ports: list[str] | None = None) -> list[dict[str, str]]:
         service_elem = port.find('service')
         state = state_elem.get('state') if state_elem is not None else ''
         service = service_elem.get('name') if service_elem is not None else ''
-        results.append({'port': portid, 'state': state, 'service': service})
+        item = {'port': portid, 'state': state, 'service': service}
+        if service_elem is not None:
+            product = service_elem.get('product') or ''
+            version = service_elem.get('version') or ''
+            extrainfo = service_elem.get('extrainfo') or ''
+            if product or version or extrainfo:
+                item['service_info'] = ' '.join(
+                    [s for s in [product, version, extrainfo] if s]
+                ).strip()
+        results.append(item)
     return results
 
 
 def main():
-    if len(sys.argv) < 2:
-        print('Usage: port_scan.py <host> [port_list]', file=sys.stderr)
-        sys.exit(1)
-    host = sys.argv[1]
-    ports = sys.argv[2].split(',') if len(sys.argv) >= 3 else []
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run nmap port scan")
+    parser.add_argument("host", help="Target host")
+    parser.add_argument("port_list", nargs="?", help="Comma separated ports")
+    parser.add_argument("--service", action="store_true", help="Enable service version detection (-sV)")
+    parser.add_argument("--os", action="store_true", help="Enable OS detection (-O)")
+    parser.add_argument("--script", help="Comma separated nmap scripts")
+    args = parser.parse_args()
+
+    ports = args.port_list.split(',') if args.port_list else []
+    scripts = args.script.split(',') if args.script else None
     try:
-        res = run_scan(host, ports if ports else None)
-        print(json.dumps({'host': host, 'ports': res}))
+        res = run_scan(
+            args.host,
+            ports if ports else None,
+            service=args.service,
+            os_detect=args.os,
+            scripts=scripts,
+        )
+        print(json.dumps({'host': args.host, 'ports': res}))
     except Exception as e:
         print(json.dumps({'error': str(e)}))
         sys.exit(1)

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -12,5 +12,14 @@ class PortScanScriptTest(unittest.TestCase):
                 'nmap', '-p-', '-oX', '-', '1.1.1.1'
             ], capture_output=True, text=True)
 
+    def test_run_scan_with_options(self):
+        xml = "<nmaprun></nmaprun>"
+        with patch('subprocess.run') as m:
+            m.return_value = MagicMock(returncode=0, stdout=xml)
+            port_scan.run_scan('1.1.1.1', [], service=True, os_detect=True, scripts=['vuln'])
+            m.assert_called_with([
+                'nmap', '-sV', '-O', '--script', 'vuln', '-p-', '-oX', '-', '1.1.1.1'
+            ], capture_output=True, text=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `DEFAULT_PORTS` and allow detailed options in LAN port scan
- add service/OS/script options to `port_scan.py`
- support these options from `lan_port_scan.py`
- update documentation
- expand unit tests for `port_scan` options

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b756ab208323aeb746f7b38c1069