### PR TITLE
Change app display name to NWCD

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="nwc_densetsu"
+        android:label="NWCD"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nwc Densetsu</string>
+        <string>NWCD</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>nwc_densetsu</string>
+        <string>NWCD</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      title: 'NWC Densetsu',
+      title: 'NWCD',
       home: HomePage(),
     );
   }
@@ -123,7 +123,7 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('NWC Densetsu')),
+      appBar: AppBar(title: const Text('NWCD')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "nwc_densetsu");
+    gtk_header_bar_set_title(header_bar, "NWCD");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "nwc_densetsu");
+    gtk_window_set_title(window, "NWCD");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = nwc_densetsu
+PRODUCT_NAME = NWCD
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.nwcDensetsu

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -15,7 +15,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
 
     // Verify that the main title and LAN scan button are present.
-    expect(find.text('NWC Densetsu'), findsOneWidget);
+    expect(find.text('NWCD'), findsOneWidget);
     expect(find.text('LANスキャン'), findsOneWidget);
     expect(find.text('レポート保存'), findsOneWidget);
   });

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="nwc_densetsu">
+  <meta name="apple-mobile-web-app-title" content="NWCD">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>nwc_densetsu</title>
+  <title>NWCD</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "nwc_densetsu",
-    "short_name": "nwc_densetsu",
+    "name": "NWCD",
+    "short_name": "NWCD",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "nwc_densetsu" "\0"
+            VALUE "FileDescription", "NWCD" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "nwc_densetsu" "\0"
+            VALUE "InternalName", "NWCD" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "nwc_densetsu.exe" "\0"
-            VALUE "ProductName", "nwc_densetsu" "\0"
+            VALUE "OriginalFilename", "NWCD.exe" "\0"
+            VALUE "ProductName", "NWCD" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"nwc_densetsu", origin, size)) {
+  if (!window.Create(L"NWCD", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- update visible titles from "NWC Densetsu"/"nwc_densetsu" to "NWCD"
- adjust platform-specific configs for Android, iOS, macOS, Linux, Windows, and Web
- fix tests to check for new title

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868c34a5c7c832394e2fa599c8bc8e2