### PR TITLE
Concurrent scanning with progress widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:nwc_densetsu/network_scan.dart'
     show NetworkDevice;
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nwc_densetsu/utils/file_utils.dart' as utils;
+import 'package:nwc_densetsu/progress_list.dart';
 
 void main() {
   runApp(const MyApp());
@@ -39,6 +40,8 @@ class _HomePageState extends State<HomePage> {
   List<NetworkDevice> _devices = <NetworkDevice>[];
   List<SecurityReport> _reports = [];
   bool _lanScanning = false;
+  final Map<String, int> _progress = {};
+  static const int _taskCount = 3; // port, SSL, SPF
 
 
   Future<void> _runLanScan() async {
@@ -48,6 +51,7 @@ class _HomePageState extends State<HomePage> {
       _scanResults = [];
       _reports = [];
       _output = '診断中...\n';
+      _progress.clear();
     });
 
     final devices = await net.scanNetwork(onError: (msg) {
@@ -58,6 +62,9 @@ class _HomePageState extends State<HomePage> {
     });
     setState(() {
       _devices = devices;
+      for (final d in devices) {
+        _progress[d.ip] = 0;
+      }
     });
 
     final buffer = StringBuffer();
@@ -67,16 +74,31 @@ class _HomePageState extends State<HomePage> {
       final pingRes = await diag.runPing(ip);
       buffer.writeln(pingRes);
 
-      final summary = await diag.scanPorts(ip);
+      final portFuture = diag.scanPorts(ip).then((value) {
+        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        return value;
+      });
+      final sslFuture = diag.checkSslCertificate(ip).then((value) {
+        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        return value;
+      });
+      final spfFuture = diag.checkSpfRecord(ip).then((value) {
+        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        return value;
+      });
+
+      final results = await Future.wait([portFuture, sslFuture, spfFuture]);
+
+      final summary = results[0] as PortScanSummary;
+      final sslRes = results[1] as SslResult;
+      final spfRes = results[2] as String;
+
       _scanResults.add(summary);
       for (final r in summary.results) {
         buffer.writeln('Port ${r.port}: ${r.state} ${r.service}');
       }
 
-      final sslRes = await diag.checkSslCertificate(ip);
       buffer.writeln(sslRes.message);
-
-      final spfRes = await diag.checkSpfRecord(ip);
       buffer.writeln(spfRes);
 
       final report = await diag.runSecurityReport(
@@ -96,6 +118,8 @@ class _HomePageState extends State<HomePage> {
       if (report.score <= 5) {
         buffer.writeln('UTM導入を推奨します');
       }
+
+      setState(() => _progress.remove(ip));
     }
 
     setState(() {
@@ -138,6 +162,10 @@ class _HomePageState extends State<HomePage> {
             if (_lanScanning) ...[
               const SizedBox(height: 8),
               const CircularProgressIndicator(),
+              ScanningProgressList(
+                progress: _progress,
+                taskCount: _taskCount,
+              ),
             ],
             const SizedBox(height: 8),
             ElevatedButton(

--- a/lib/progress_list.dart
+++ b/lib/progress_list.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+/// Displays progress indicators for multiple hosts.
+class ScanningProgressList extends StatelessWidget {
+  final Map<String, int> progress;
+  final int taskCount;
+
+  const ScanningProgressList({
+    super.key,
+    required this.progress,
+    required this.taskCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (progress.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final e in progress.entries) ...[
+          Text('Scanning ${e.key}'),
+          LinearProgressIndicator(value: e.value / taskCount),
+          const SizedBox(height: 4),
+        ],
+      ],
+    );
+  }
+}
+

--- a/test/progress_list_test.dart
+++ b/test/progress_list_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/progress_list.dart';
+
+void main() {
+  testWidgets('progress list renders entries', (tester) async {
+    final progress = {'1.1.1.1': 2, '2.2.2.2': 1};
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ScanningProgressList(progress: progress, taskCount: 3),
+        ),
+      ),
+    );
+    expect(find.byType(LinearProgressIndicator), findsNWidgets(2));
+    expect(find.textContaining('Scanning'), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
- run SSL/port/SPF checks concurrently in `_runLanScan`
- track scan progress per host and display it
- add `ScanningProgressList` widget
- add widget test for progress list rendering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c42833e08323a1acd0243c8579d0