### PR TITLE
Add tests for network utilities

### DIFF
--- a/test/test_external_ip_report.py
+++ b/test/test_external_ip_report.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import external_ip_report
+
+class ExternalIPReportTest(unittest.TestCase):
+    def test_classify_port_encrypted(self):
+        self.assertEqual(external_ip_report.classify_port(443), "\u6697\u53f7\u5316")
+
+    def test_classify_port_unencrypted(self):
+        self.assertEqual(external_ip_report.classify_port(80), "\u975e\u6697\u53f7\u5316")
+
+    def test_classify_port_unknown(self):
+        self.assertEqual(external_ip_report.classify_port(12345), "\u4e0d\u660e")
+
+    def test_reverse_dns_success(self):
+        with patch('socket.gethostbyaddr') as mock_get:
+            mock_get.return_value = ('example.com', [], ['93.184.216.34'])
+            self.assertEqual(external_ip_report.reverse_dns('93.184.216.34'), 'example.com')
+
+    def test_reverse_dns_failure(self):
+        with patch('socket.gethostbyaddr', side_effect=Exception()):
+            self.assertEqual(external_ip_report.reverse_dns('8.8.8.8'), '')
+
+    def test_geoip_country_reader_none(self):
+        self.assertEqual(external_ip_report.geoip_country(None, '1.1.1.1'), '')
+
+    def test_geoip_country_success(self):
+        reader = MagicMock()
+        resp = MagicMock()
+        resp.country.iso_code = 'US'
+        reader.country.return_value = resp
+        self.assertEqual(external_ip_report.geoip_country(reader, '1.1.1.1'), 'US')
+        reader.country.assert_called_once_with('1.1.1.1')
+
+    def test_geoip_country_exception(self):
+        reader = MagicMock()
+        reader.country.side_effect = Exception()
+        self.assertEqual(external_ip_report.geoip_country(reader, '1.1.1.1'), '')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_firewall_check.py
+++ b/test/test_firewall_check.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import firewall_check
+
+class FirewallCheckTest(unittest.TestCase):
+    @patch('firewall_check.os.name', 'nt')
+    @patch('firewall_check.subprocess.run')
+    def test_get_defender_status_enabled(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='True\n')
+        self.assertTrue(firewall_check.get_defender_status())
+
+    @patch('firewall_check.os.name', 'nt')
+    @patch('firewall_check.subprocess.run')
+    def test_get_defender_status_disabled(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='False\n')
+        self.assertFalse(firewall_check.get_defender_status())
+
+    @patch('firewall_check.os.name', 'posix')
+    def test_get_defender_status_non_windows(self):
+        self.assertIsNone(firewall_check.get_defender_status())
+
+    @patch('firewall_check.os.name', 'nt')
+    @patch('firewall_check.subprocess.run')
+    def test_get_firewall_status_windows_on(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='State ON\n')
+        self.assertTrue(firewall_check.get_firewall_status())
+
+    @patch('firewall_check.os.name', 'nt')
+    @patch('firewall_check.subprocess.run')
+    def test_get_firewall_status_windows_off(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='State OFF\n')
+        self.assertFalse(firewall_check.get_firewall_status())
+
+    @patch('firewall_check.os.name', 'posix')
+    @patch('firewall_check.subprocess.run')
+    def test_get_firewall_status_linux_active(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='Status: active\n')
+        self.assertTrue(firewall_check.get_firewall_status())
+
+    @patch('firewall_check.os.name', 'posix')
+    @patch('firewall_check.subprocess.run')
+    def test_get_firewall_status_linux_inactive(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='inactive\n')
+        self.assertFalse(firewall_check.get_firewall_status())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover external IP helpers: `classify_port`, `reverse_dns`, `geoip_country`
- test Windows Defender and firewall helpers using mocks

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_6868c4293b4c8323bde523dc28dacb6f