### PR TITLE
Fix diagnostics import

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:nwc_densetsu/diagnostics.dart' as diag;
 import 'package:nwc_densetsu/diagnostics.dart'
-    show PortScanSummary, SecurityReport;
+    show PortScanSummary, SecurityReport, SslResult;
 import 'package:nwc_densetsu/network_scan.dart' as net;
 import 'package:nwc_densetsu/network_scan.dart'
     show NetworkDevice;


### PR DESCRIPTION
## Summary
- import SslResult in main.dart for compile-time analyzer

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb3b0bd0832380661e1761bd9d10