### PR TITLE
Add PDF report generation utility

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:nwc_densetsu/network_scan.dart'
     show NetworkDevice;
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nwc_densetsu/utils/file_utils.dart' as utils;
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 
 void main() {
@@ -131,16 +132,17 @@ class _HomePageState extends State<HomePage> {
 
 
   Future<void> _saveReportFile() async {
-    final now = DateTime.now();
-    final stamp =
-        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}_${now.hour.toString().padLeft(2, '0')}-${now.minute.toString().padLeft(2, '0')}';
-    final path = await utils.getSavePath(suggestedName: 'report_$stamp.txt');
-    if (path == null) return;
-    final file = File(path);
-    await file.writeAsString(_output);
-    if (mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('保存完了')));
+    try {
+      await report_utils.savePdfReport(_reports);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('保存完了')));
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('保存失敗: $e')));
+      }
     }
   }
 

--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../diagnostics.dart' show SecurityReport;
+import 'file_utils.dart';
+
+/// Generates a PDF report from [reports] using the bundled Python script
+/// and saves it to a location chosen by the user.
+Future<void> savePdfReport(List<SecurityReport> reports) async {
+  // Create temporary directory for intermediate files
+  final tempDir = await Directory.systemTemp.createTemp('nwcd');
+  try {
+    final jsonPath = p.join(tempDir.path, 'devices.json');
+    final jsonList = [
+      for (final r in reports)
+        {
+          'ip': r.ip,
+          'open_ports': r.openPorts,
+          'countries': [if (r.geoip.isNotEmpty) r.geoip],
+        },
+    ];
+    await File(jsonPath).writeAsString(jsonEncode(jsonList));
+
+    final htmlPath = p.join(tempDir.path, 'report.html');
+    final result = await Process.run('python', [
+      'generate_html_report.py',
+      jsonPath,
+      '-o',
+      htmlPath,
+      '--pdf',
+    ]);
+
+    if (result.exitCode != 0) {
+      throw Exception(result.stderr.toString());
+    }
+
+    final pdfPath = p.withoutExtension(htmlPath) + '.pdf';
+    final savePath = await getSavePath(suggestedName: 'report.pdf');
+    if (savePath != null) {
+      final pdfFile = File(pdfPath);
+      if (await pdfFile.exists()) {
+        await pdfFile.copy(savePath);
+      }
+    }
+  } finally {
+    try {
+      await tempDir.delete(recursive: true);
+    } catch (_) {
+      // ignore cleanup errors
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- generate PDF reports via a new `savePdfReport` utility
- integrate PDF saving with the existing save button

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ca9a4d408323b000011489b7c300