### PR TITLE
Add diagnostic result page with PDF export

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:nwc_densetsu/network_scan.dart'
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nwc_densetsu/utils/file_utils.dart' as utils;
 import 'package:nwc_densetsu/progress_list.dart';
+import 'package:nwc_densetsu/result_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -144,6 +145,30 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  void _openResultPage() {
+    final items = [
+      const DiagnosticItem(
+        name: 'ポート開放',
+        description: '不要なポートが開いています',
+        status: 'warning',
+      ),
+      const DiagnosticItem(
+        name: 'SSL 証明書',
+        description: '証明書の有効期限切れ',
+        status: 'danger',
+      ),
+    ];
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DiagnosticResultPage(
+          securityScore: 7,
+          riskScore: 4,
+          items: items,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -171,6 +196,11 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: _saveReportFile,
               child: const Text('レポート保存'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _openResultPage,
+              child: const Text('診断結果ページ'),
             ),
             const SizedBox(height: 16),
             for (final summary in _scanResults) ...[

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+class DiagnosticItem {
+  final String name;
+  final String description;
+  final String status;
+
+  const DiagnosticItem({
+    required this.name,
+    required this.description,
+    required this.status,
+  });
+}
+
+class DiagnosticResultPage extends StatelessWidget {
+  final int securityScore;
+  final int riskScore;
+  final List<DiagnosticItem> items;
+
+  const DiagnosticResultPage({
+    super.key,
+    required this.securityScore,
+    required this.riskScore,
+    required this.items,
+  });
+
+  Color _scoreColor(int score) {
+    if (score >= 8) return Colors.green;
+    if (score >= 5) return Colors.orange;
+    return Colors.redAccent;
+  }
+
+  String _scoreMessage(int score) {
+    if (score >= 8) return '社内ネットワークは安全です';
+    if (score >= 5) return '注意が必要です';
+    return '危険な状態です';
+  }
+
+  Future<void> _saveReport(BuildContext context) async {
+    try {
+      final result = await Process.run(
+        'python',
+        ['generate_html_report.py', 'sample_devices.json', '--pdf'],
+      );
+      final out = result.stdout.toString();
+      final match = RegExp(r'PDF written to (.+\.pdf)').firstMatch(out);
+      final path = match?.group(1) ?? 'scan_report.pdf';
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('PDF 保存: $path')));
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('生成失敗: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('診断結果')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Security Score: $securityScore',
+              style: TextStyle(
+                fontSize: 32,
+                color: _scoreColor(securityScore),
+              ),
+            ),
+            Text(_scoreMessage(securityScore)),
+            const SizedBox(height: 16),
+            Text(
+              'Risk Score: $riskScore',
+              style: TextStyle(
+                fontSize: 32,
+                color: _scoreColor(riskScore),
+              ),
+            ),
+            Text(_scoreMessage(riskScore)),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: items.length,
+                itemBuilder: (context, index) {
+                  final item = items[index];
+                  return Card(
+                    margin: const EdgeInsets.symmetric(vertical: 4),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(item.name,
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.bold)),
+                          const SizedBox(height: 4),
+                          Text(item.description),
+                          const SizedBox(height: 4),
+                          Text('現状: ${item.status}'),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.center,
+              child: ElevatedButton(
+                onPressed: () => _saveReport(context),
+                child: const Text('レポート保存'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `DiagnosticResultPage` widget to show scores and diagnostic items
- export report to PDF by running `generate_html_report.py`
- link the new page from `HomePage`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ca995734832397b624626e119e65