### PR TITLE
Add ResultPage widget

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
 
 class DiagnosticItem {
   final String name;
@@ -122,6 +123,90 @@ class DiagnosticResultPage extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class ResultPage extends StatelessWidget {
+  final List<SecurityReport> reports;
+  final VoidCallback onSave;
+
+  const ResultPage({super.key, required this.reports, required this.onSave});
+
+  Color _scoreColor(int score) {
+    if (score >= 8) return Colors.green;
+    if (score >= 5) return Colors.orange;
+    return Colors.redAccent;
+  }
+
+  String _riskState(int score) {
+    if (score >= 8) return '安全';
+    if (score >= 5) return '注意';
+    return '危険';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Scores'),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('IP')),
+              DataColumn(label: Text('Score')),
+              DataColumn(label: Text('Ports')),
+              DataColumn(label: Text('Country')),
+            ],
+            rows: [
+              for (final r in reports)
+                DataRow(
+                  color: WidgetStateProperty.all(
+                    _scoreColor(r.score),
+                  ),
+                  cells: [
+                    DataCell(Text(r.ip)),
+                    DataCell(Text(r.score.toString())),
+                    DataCell(Text(r.openPorts.join(','))),
+                    DataCell(Text(r.geoip)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final r in reports)
+                  for (final risk in r.risks)
+                    Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4),
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Text(
+                          '${_riskState(r.score)} → '
+                          '${risk.description} → ${risk.countermeasure}',
+                        ),
+                      ),
+                    ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Align(
+          alignment: Alignment.center,
+          child: ElevatedButton(
+            onPressed: onSave,
+            child: const Text('レポート保存'),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- expose a new `ResultPage` widget for displaying `SecurityReport`s
- implement score color and risk state handling

## Testing
- `PYTHONPATH=. pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a86b9dfd88323ad0eaa9a2f9e10ed