### PR TITLE
Fix SslResult export and clean imports

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'ssl_result.dart';
+export 'ssl_result.dart';
 import 'network_scan.dart' as net;
 
 typedef LanDevice = net.NetworkDevice;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:io';
-
 import 'package:nwc_densetsu/diagnostics.dart' as diag;
 import 'package:nwc_densetsu/diagnostics.dart'
     show PortScanSummary, SecurityReport, SslResult;
@@ -8,7 +6,6 @@ import 'package:nwc_densetsu/network_scan.dart' as net;
 import 'package:nwc_densetsu/network_scan.dart'
     show NetworkDevice;
 import 'package:fl_chart/fl_chart.dart';
-import 'package:nwc_densetsu/utils/file_utils.dart' as utils;
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';


### PR DESCRIPTION
## Summary
- remove unused imports from `main.dart`
- re-export `SslResult` from `diagnostics.dart`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a88d04288832395998c1553999f35