### PR TITLE
Add network speed output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install -r requirements.txt
   - 代表的なポートへの接続可否
   - SSL 証明書の発行者と有効期限
   - DNS の SPF レコード
-  - ネットワーク速度測定 (download/upload/ping)
+  - ネットワーク速度測定 (download/upload/ping) の結果表示
   - これらを基にしたセキュリティスコア（0〜10）
 
 この最小構成を起点に、今後の機能追加を行っていきます。
@@ -191,6 +191,7 @@ Windows 以外の環境では `defender_enabled` が `null` となります。
 
 `network_speed.py` は `speedtest-cli` を利用してダウンロード速度、アップロード速度、
 および ping を計測します。
+LAN スキャン時に計測され、結果は画面にも表示されます。
 
 ```bash
 python network_speed.py


### PR DESCRIPTION
## Summary
- measure network speed when starting LAN scan
- display network speed results in the app
- document that the speed test result is shown in the app

## Testing
- `python -m unittest discover -s test -p 'test_*.py'`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d3c02748323a0c6dcf68bdd9f9a