### PR TITLE
Use DataTable for diagnostic results

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -150,11 +150,13 @@ class _HomePageState extends State<HomePage> {
         name: 'ポート開放',
         description: '不要なポートが開いています',
         status: 'warning',
+        action: '閉じる',
       ),
       const DiagnosticItem(
         name: 'SSL 証明書',
         description: '証明書の有効期限切れ',
         status: 'danger',
+        action: '更新する',
       ),
     ];
     Navigator.of(context).push(

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -6,11 +6,13 @@ class DiagnosticItem {
   final String name;
   final String description;
   final String status;
+  final String action;
 
   const DiagnosticItem({
     required this.name,
     required this.description,
     required this.status,
+    required this.action,
   });
 }
 
@@ -87,29 +89,25 @@ class DiagnosticResultPage extends StatelessWidget {
             Text(_scoreMessage(riskScore)),
             const SizedBox(height: 16),
             Expanded(
-              child: ListView.builder(
-                itemCount: items.length,
-                itemBuilder: (context, index) {
-                  final item = items[index];
-                  return Card(
-                    margin: const EdgeInsets.symmetric(vertical: 4),
-                    child: Padding(
-                      padding: const EdgeInsets.all(8),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(item.name,
-                              style: const TextStyle(
-                                  fontWeight: FontWeight.bold)),
-                          const SizedBox(height: 4),
-                          Text(item.description),
-                          const SizedBox(height: 4),
-                          Text('現状: ${item.status}'),
-                        ],
-                      ),
-                    ),
-                  );
-                },
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columns: const [
+                    DataColumn(label: Text('項目名')),
+                    DataColumn(label: Text('説明')),
+                    DataColumn(label: Text('現状')),
+                    DataColumn(label: Text('推奨対策')),
+                  ],
+                  rows: [
+                    for (final item in items)
+                      DataRow(cells: [
+                        DataCell(Text(item.name)),
+                        DataCell(Text(item.description)),
+                        DataCell(Text(item.status)),
+                        DataCell(Text(item.action)),
+                      ]),
+                  ],
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -35,4 +35,42 @@ void main() {
 
     expect(find.byType(Card), findsNWidgets(2));
   });
+
+  testWidgets('DiagnosticResultPage shows items in a DataTable', (tester) async {
+    const items = [
+      DiagnosticItem(
+        name: 'ポート開放',
+        description: '説明1',
+        status: 'warning',
+        action: '閉じる',
+      ),
+      DiagnosticItem(
+        name: 'SSL 証明書',
+        description: '説明2',
+        status: 'danger',
+        action: '更新する',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 5,
+          riskScore: 3,
+          items: items,
+        ),
+      ),
+    );
+
+    final tableFinder = find.byType(DataTable);
+    expect(tableFinder, findsOneWidget);
+    final dataTable = tester.widget<DataTable>(tableFinder);
+    expect(dataTable.columns.length, 4);
+    expect(find.text('項目名'), findsOneWidget);
+    expect(find.text('説明'), findsOneWidget);
+    expect(find.text('現状'), findsOneWidget);
+    expect(find.text('推奨対策'), findsOneWidget);
+    expect(find.text('ポート開放'), findsOneWidget);
+    expect(find.text('閉じる'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- show diagnostic details using `DataTable`
- add recommended action field to `DiagnosticItem`
- update example items
- test table layout for `DiagnosticResultPage`

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d216cd883238ed512b1ab77b854