### PR TITLE
Add colored status to DiagnosticResultPage

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -38,6 +38,32 @@ class DiagnosticResultPage extends StatelessWidget {
     return '危険な状態です';
   }
 
+  Color _statusColor(String status) {
+    switch (status) {
+      case 'safe':
+        return Colors.green;
+      case 'warning':
+        return Colors.orange;
+      case 'danger':
+        return Colors.red;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  IconData _statusIcon(String status) {
+    switch (status) {
+      case 'safe':
+        return Icons.check_circle;
+      case 'warning':
+        return Icons.warning;
+      case 'danger':
+        return Icons.error;
+      default:
+        return Icons.help_outline;
+    }
+  }
+
   Future<void> _saveReport(BuildContext context) async {
     try {
       final result = await Process.run(
@@ -104,7 +130,20 @@ class DiagnosticResultPage extends StatelessWidget {
                           const SizedBox(height: 4),
                           Text(item.description),
                           const SizedBox(height: 4),
-                          Text('現状: ${item.status}'),
+                          Row(
+                            children: [
+                              const Text('現状: '),
+                              Icon(
+                                _statusIcon(item.status),
+                                color: _statusColor(item.status),
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                item.status,
+                                style: TextStyle(color: _statusColor(item.status)),
+                              ),
+                            ],
+                          ),
                         ],
                       ),
                     ),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/result_page.dart';
+
+void main() {
+  testWidgets('DiagnosticResultPage shows colored status labels', (tester) async {
+    const items = [
+      DiagnosticItem(name: 'A', description: 'd', status: 'safe'),
+      DiagnosticItem(name: 'B', description: 'd', status: 'warning'),
+      DiagnosticItem(name: 'C', description: 'd', status: 'danger'),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 9,
+          riskScore: 2,
+          items: items,
+        ),
+      ),
+    );
+
+    final safeText = tester.widget<Text>(find.text('safe'));
+    final warningText = tester.widget<Text>(find.text('warning'));
+    final dangerText = tester.widget<Text>(find.text('danger'));
+
+    expect(safeText.style?.color, Colors.green);
+    expect(warningText.style?.color, Colors.orange);
+    expect(dangerText.style?.color, Colors.red);
+  });
+}


### PR DESCRIPTION
## Summary
- show diagnostic result statuses with color and icon
- map safe/warning/danger statuses to green/orange/red
- add widget test for status color mapping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d2051248323a4f6067a209bd43c