### PR TITLE
Add action field to DiagnosticItem with UI and tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -150,11 +150,13 @@ class _HomePageState extends State<HomePage> {
         name: 'ポート開放',
         description: '不要なポートが開いています',
         status: 'warning',
+        action: '不要なポートを閉じる',
       ),
       const DiagnosticItem(
         name: 'SSL 証明書',
         description: '証明書の有効期限切れ',
         status: 'danger',
+        action: '証明書を更新する',
       ),
     ];
     Navigator.of(context).push(

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -6,11 +6,13 @@ class DiagnosticItem {
   final String name;
   final String description;
   final String status;
+  final String action;
 
   const DiagnosticItem({
     required this.name,
     required this.description,
     required this.status,
+    required this.action,
   });
 }
 
@@ -105,6 +107,8 @@ class DiagnosticResultPage extends StatelessWidget {
                           Text(item.description),
                           const SizedBox(height: 4),
                           Text('現状: ${item.status}'),
+                          const SizedBox(height: 4),
+                          Text('推奨対策: ${item.action}'),
                         ],
                       ),
                     ),

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -35,4 +35,30 @@ void main() {
 
     expect(find.byType(Card), findsNWidgets(2));
   });
+
+  testWidgets('DiagnosticResultPage shows action text', (WidgetTester tester) async {
+    const items = [
+      DiagnosticItem(
+        name: 'チェック1',
+        description: '説明',
+        status: 'ok',
+        action: '対策する',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 5,
+          riskScore: 4,
+          items: items,
+        ),
+      ),
+    );
+
+    expect(find.text('チェック1'), findsOneWidget);
+    expect(find.text('説明'), findsOneWidget);
+    expect(find.text('現状: ok'), findsOneWidget);
+    expect(find.text('推奨対策: 対策する'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- expand `DiagnosticItem` with new `action` field
- show recommended countermeasure in `DiagnosticResultPage`
- update sample usage in the demo app
- ensure widget test verifies rendering of action text

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d1d14b88323a5859f6c4cdabc85