### PR TITLE
Fix _openResultPage diagnostic item

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -174,7 +174,6 @@ class _HomePageState extends State<HomePage> {
         description: '証明書の有効期限切れ',
         status: 'danger',
         action: '証明書を更新する',
-=======
       ),
     ];
     Navigator.of(context).push(


### PR DESCRIPTION
## Summary
- fix `_openResultPage` sample data

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9478e3a483239eb4e800abe1b60e