### PR TITLE
Add topology view button

### DIFF
--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -52,3 +52,22 @@ Future<void> savePdfReport(List<SecurityReport> reports) async {
     }
   }
 }
+
+/// Runs `generate_topology.py` and returns the path to the generated diagram.
+Future<String> generateTopologyDiagram() async {
+  final tempDir = await Directory.systemTemp.createTemp('nwcd_topology');
+  final imgPath = p.join(tempDir.path, 'topology.png');
+  try {
+    final result = await Process.run('python', [
+      'generate_topology.py',
+      '--output',
+      imgPath,
+    ]);
+    if (result.exitCode != 0) {
+      throw Exception(result.stderr.toString());
+    }
+    return imgPath;
+  } catch (e) {
+    rethrow;
+  }
+}

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/result_page.dart';
+import 'dart:io';
 
 void main() {
   testWidgets('ResultPage displays scores and items', (WidgetTester tester) async {
@@ -60,5 +61,26 @@ void main() {
     expect(find.text('説明'), findsOneWidget);
     expect(find.text('現状: ok'), findsOneWidget);
     expect(find.text('推奨対策: 対策する'), findsOneWidget);
+  });
+
+  testWidgets('Topology button shows image dialog', (tester) async {
+    final imgFile = File('${Directory.systemTemp.path}/dummy.png');
+    await imgFile.writeAsBytes(List.filled(10, 0));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 5,
+          riskScore: 4,
+          items: const [],
+          onGenerateTopology: () async => imgFile.path,
+        ),
+      ),
+    );
+
+    expect(find.text('トポロジ表示'), findsOneWidget);
+    await tester.tap(find.text('トポロジ表示'));
+    await tester.pumpAndSettle();
+    expect(find.byType(Image), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `generateTopologyDiagram` in utils to run `generate_topology.py`
- add topology button and callback to `DiagnosticResultPage`
- show topology image in a dialog
- test topology button rendering and dialog

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b180375e8832384dc04234e2f40a8