### PR TITLE
Add network topology generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ python lan_security_check.py  # 自動検出されたサブネットを使用
 python lan_security_check.py 10.0.0.0/24  # サブネットを指定する場合
 ```
 
+## Network Topology
+
+`generate_topology.py` を使うと `discover_hosts.py` や `lan_port_scan.py` の JSON 出力からネットワーク図を生成できます。
+
+```bash
+python generate_topology.py scan_results.json -o topology.png
+```
+
+`-o` には `.png`, `.svg`, `.dot` のいずれかを指定します。
+
 ## スキャン実行時の注意
 
 本ツールによるホスト探索やポートスキャンは、運用者が明示的な許可を得たネットワークでのみ実行してください。許可なく他者のネットワークをスキャンすると、不正アクセス禁止法などの法令に抵触し、民事・刑事上の責任を問われる可能性があります。

--- a/generate_topology.py
+++ b/generate_topology.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Generate network topology graph from scan results."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from graphviz import Graph
+
+
+def _extract_hosts(data: Any) -> Iterable[dict]:
+    """Return iterable of hosts from discover_hosts or lan_port_scan output."""
+    if isinstance(data, dict) and "hosts" in data:
+        return data.get("hosts", [])
+    return data
+
+
+def build_graph(data: Any) -> Graph:
+    """Build a graphviz Graph from parsed scan data."""
+    hosts = list(_extract_hosts(data))
+    g = Graph("Network")
+    g.attr("node", shape="box")
+    g.node("LAN")
+    for host in hosts:
+        ip = host.get("ip") or host.get("device") or "unknown"
+        label = ip
+        vendor = host.get("vendor")
+        if vendor:
+            label = f"{ip}\n{vendor}"
+        g.node(ip, label=label)
+        g.edge("LAN", ip)
+    return g
+
+
+def save_graph(graph: Graph, output: str) -> None:
+    """Save graph to PNG/SVG or DOT depending on extension."""
+    path = Path(output)
+    if path.suffix.lower() in {".png", ".svg"}:
+        fmt = path.suffix.lower()[1:]
+        graph.render(path.stem, path.parent, format=fmt, cleanup=True)
+    else:
+        graph.save(filename=str(path))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create network topology diagram")
+    parser.add_argument("input", help="JSON from discover_hosts.py or lan_port_scan.py")
+    parser.add_argument("-o", "--output", default="topology.png", help="Output file (.png/.svg/.dot)")
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    graph = build_graph(data)
+    save_graph(graph, args.output)
+    print(f"Topology written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pdfkit
 weasyprint
 
 speedtest-cli
+graphviz

--- a/test/test_generate_topology.py
+++ b/test/test_generate_topology.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+from pathlib import Path
+import tempfile
+
+import generate_topology
+
+
+class GenerateTopologyTest(unittest.TestCase):
+    def test_build_graph_from_discover_hosts(self):
+        data = {"hosts": [{"ip": "192.168.1.2", "vendor": "X"}]}
+        g = generate_topology.build_graph(data)
+        src = g.source
+        self.assertIn("192.168.1.2", src)
+        self.assertIn('LAN -- "192.168.1.2"', src)
+
+    def test_save_graph_dot(self):
+        g = generate_topology.Graph("test")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "out.dot"
+            generate_topology.save_graph(g, str(path))
+            self.assertTrue(path.exists())
+            self.assertGreater(path.stat().st_size, 0)
+
+    @patch.object(generate_topology.Graph, "render")
+    def test_save_graph_png_calls_render(self, mock_render):
+        g = generate_topology.Graph("test")
+        generate_topology.save_graph(g, "out.png")
+        mock_render.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `generate_topology.py` for drawing a simple topology graph
- include graphviz in `requirements.txt`
- unit tests for the new module
- document usage in README

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686b180292548323964a8c832c0b1d30