### PR TITLE
Fix topology function import in result page

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
-import 'package:nwc_densetsu/utils/report_utils.dart';
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 
 class DiagnosticItem {
   final String name;
@@ -106,7 +106,7 @@ class DiagnosticResultPage extends StatelessWidget {
   Future<void> _showTopology(BuildContext context) async {
     try {
       final generator = onGenerateTopology;
-      final path = await (generator ?? generateTopologyDiagram)();
+      final path = await (generator ?? report_utils.generateTopologyDiagram)();
       if (!context.mounted) return;
       await showDialog(
         context: context,


### PR DESCRIPTION
## Summary
- alias `report_utils` import in `result_page.dart`
- call `generateTopologyDiagram` through the alias

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b5775e88323ba4bbcfe277d646a