### PR TITLE
Add overall scanning progress tracking

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ class _HomePageState extends State<HomePage> {
   bool _lanScanning = false;
   final Map<String, int> _progress = {};
   static const int _taskCount = 3; // port, SSL, SPF
+  double _overallProgress = 0.0;
 
 
   Future<void> _runLanScan() async {
@@ -53,6 +54,7 @@ class _HomePageState extends State<HomePage> {
       _speed = null;
       _output = '診断中...\n';
       _progress.clear();
+      _overallProgress = 0.0;
     });
 
     final speed = await diag.measureNetworkSpeed();
@@ -83,6 +85,8 @@ class _HomePageState extends State<HomePage> {
         _progress[d.ip] = 0;
       }
     });
+    final totalTasks = devices.length * _taskCount;
+    var completedTasks = 0;
 
     for (final d in devices) {
       final ip = d.ip;
@@ -91,15 +95,30 @@ class _HomePageState extends State<HomePage> {
       buffer.writeln(pingRes);
 
       final portFuture = diag.scanPorts(ip).then((value) {
-        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        setState(() {
+          _progress[ip] = (_progress[ip] ?? 0) + 1;
+          completedTasks++;
+          _overallProgress =
+              totalTasks > 0 ? completedTasks / totalTasks : 1.0;
+        });
         return value;
       });
       final sslFuture = diag.checkSslCertificate(ip).then((value) {
-        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        setState(() {
+          _progress[ip] = (_progress[ip] ?? 0) + 1;
+          completedTasks++;
+          _overallProgress =
+              totalTasks > 0 ? completedTasks / totalTasks : 1.0;
+        });
         return value;
       });
       final spfFuture = diag.checkSpfRecord(ip).then((value) {
-        setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
+        setState(() {
+          _progress[ip] = (_progress[ip] ?? 0) + 1;
+          completedTasks++;
+          _overallProgress =
+              totalTasks > 0 ? completedTasks / totalTasks : 1.0;
+        });
         return value;
       });
 
@@ -142,6 +161,7 @@ class _HomePageState extends State<HomePage> {
       _output = buffer.toString();
       _lanScanning = false;
       _devices = devices;
+      _overallProgress = 1.0;
     });
   }
 
@@ -235,6 +255,7 @@ class _HomePageState extends State<HomePage> {
               ScanningProgressList(
                 progress: _progress,
                 taskCount: _taskCount,
+                overallProgress: _overallProgress,
               ),
             ],
             if (_speed != null) ...[

--- a/lib/progress_list.dart
+++ b/lib/progress_list.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart';
 class ScanningProgressList extends StatelessWidget {
   final Map<String, int> progress;
   final int taskCount;
+  final double overallProgress;
 
   const ScanningProgressList({
     super.key,
     required this.progress,
     required this.taskCount,
+    required this.overallProgress,
   });
 
   @override
@@ -17,6 +19,8 @@ class ScanningProgressList extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        LinearProgressIndicator(value: overallProgress),
+        const SizedBox(height: 8),
         for (final e in progress.entries) ...[
           Text('Scanning ${e.key}'),
           LinearProgressIndicator(value: e.value / taskCount),

--- a/test/progress_list_test.dart
+++ b/test/progress_list_test.dart
@@ -8,11 +8,16 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: ScanningProgressList(progress: progress, taskCount: 3),
+          body: ScanningProgressList(
+            progress: progress,
+            taskCount: 3,
+            overallProgress: 0.5,
+          ),
         ),
       ),
     );
-    expect(find.byType(LinearProgressIndicator), findsNWidgets(2));
+    // One overall indicator plus one per host
+    expect(find.byType(LinearProgressIndicator), findsNWidgets(3));
     expect(find.textContaining('Scanning'), findsNWidgets(2));
   });
 }


### PR DESCRIPTION
## Summary
- show a global progress bar for LAN scans
- update scanning logic to track completed tasks
- update test for progress list widget

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b34db59e88323b4344bf965bf86ab