### PR TITLE
Remove duplicate calc_utm_items implementations

### DIFF
--- a/generate_csv_report.py
+++ b/generate_csv_report.py
@@ -6,18 +6,7 @@ import csv
 from typing import List, Dict
 
 from risk_score import calc_risk_score
-from common_constants import DANGER_COUNTRIES
-
-
-def calc_utm_items(score: int, open_ports: List[str], countries: List[str]) -> List[str]:
-    items = set()
-    if open_ports:
-        items.add("firewall")
-    if any(c.upper() in DANGER_COUNTRIES for c in countries):
-        items.add("web_filter")
-    if score >= 5:
-        items.add("ips")
-    return sorted(items)
+from report_utils import calc_utm_items
 
 
 def generate_report(devices: List[Dict]) -> List[List[str]]:

--- a/generate_html_report.py
+++ b/generate_html_report.py
@@ -10,20 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Iterable
 
 from risk_score import calc_risk_score
-from common_constants import DANGER_COUNTRIES
-try:
-    from generate_csv_report import calc_utm_items
-except Exception:  # pragma: no cover - fallback if script renamed
-
-    def calc_utm_items(score: int, open_ports: Iterable[str], countries: Iterable[str]) -> List[str]:
-        items = set()
-        if list(open_ports):
-            items.add("firewall")
-        if any(str(c).upper() in DANGER_COUNTRIES for c in countries):
-            items.add("web_filter")
-        if score >= 5:
-            items.add("ips")
-        return sorted(items)
+from report_utils import calc_utm_items
 
 try:
     import pdfkit  # type: ignore


### PR DESCRIPTION
## Summary
- keep canonical `calc_utm_items` in `report_utils`
- import `calc_utm_items` from `report_utils` in reporting scripts
- drop fallback logic and duplicates

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3551b7208323a369499d12c2236c