### PR TITLE
Add port preset dropdown

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';
+import 'package:nwc_densetsu/port_constants.dart';
 
 void main() {
   runApp(const MyApp());
@@ -40,8 +41,20 @@ class _HomePageState extends State<HomePage> {
   List<SecurityReport> _reports = [];
   diag.NetworkSpeed? _speed;
   bool _lanScanning = false;
+  String _portPreset = 'default';
   final Map<String, int> _progress = {};
   static const int _taskCount = 3; // port, SSL, SPF
+
+  List<int> get _selectedPorts {
+    switch (_portPreset) {
+      case 'quick':
+        return quickPorts;
+      case 'full':
+        return fullPorts;
+      default:
+        return defaultPortList;
+    }
+  }
 
 
   Future<void> _runLanScan() async {
@@ -90,7 +103,7 @@ class _HomePageState extends State<HomePage> {
       final pingRes = await diag.runPing(ip);
       buffer.writeln(pingRes);
 
-      final portFuture = diag.scanPorts(ip).then((value) {
+      final portFuture = diag.scanPorts(ip, _selectedPorts).then((value) {
         setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
         return value;
       });
@@ -222,6 +235,19 @@ class _HomePageState extends State<HomePage> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
+            DropdownButton<String>(
+              value: _portPreset,
+              onChanged: (val) {
+                if (val != null) {
+                  setState(() => _portPreset = val);
+                }
+              },
+              items: const [
+                DropdownMenuItem(value: 'default', child: Text('Default')),
+                DropdownMenuItem(value: 'quick', child: Text('Quick')),
+                DropdownMenuItem(value: 'full', child: Text('Full')),
+              ],
+            ),
             Tooltip(
               message: 'LAN 内のデバイスをスキャンして診断を実行します',
               child: ElevatedButton(

--- a/lib/port_constants.dart
+++ b/lib/port_constants.dart
@@ -1,4 +1,26 @@
+/// Ports used when no preset is specified.
 const List<int> defaultPortList = [
   21, 22, 23, 25, 53, 80, 110, 143,
   443, 445, 3306, 3389,
+];
+
+/// Minimal set of ports for a quick scan.
+const List<int> quickPorts = [80, 443];
+
+/// Expanded set of ports for a thorough scan.
+const List<int> fullPorts = [
+  21,
+  22,
+  23,
+  25,
+  53,
+  80,
+  110,
+  143,
+  443,
+  445,
+  3306,
+  3389,
+  5900,
+  8080,
 ];

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -6,4 +6,19 @@ void main() {
     await tester.pumpWidget(const MyApp());
     expect(find.text('LANスキャン'), findsOneWidget);
   });
+
+  testWidgets('Selecting port preset updates dropdown',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    // Default value should be displayed
+    expect(find.text('Default'), findsOneWidget);
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Quick').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Quick'), findsOneWidget);
+  });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -18,5 +18,6 @@ void main() {
     expect(find.text('NWCD'), findsOneWidget);
     expect(find.text('LANスキャン'), findsOneWidget);
     expect(find.text('レポート保存'), findsOneWidget);
+    expect(find.byType(DropdownButton<String>), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- support quick/full/default port lists
- select preset in HomePage via dropdown
- use chosen preset for scanning
- add widget tests for preset

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b351015588323a8a252ff41d353d5