### PR TITLE
Add per-country counts to LAN security check

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ python network_speed.py
 `lan_security_check.py` を実行すると、ARPスプーフィングやUPnP有効機器の有無、
 複数DHCPサーバなど LAN 内のリスクを確認できます。ローカルサブネットは自動検出
 されますが、引数で `192.168.0.0/24` など任意の範囲を指定することもできます。結果
-は JSON 形式で出力され、UTMで防御可能な項目も一覧化されます。
+は JSON 形式で出力され、UTMで防御可能な項目も一覧化されます。さらに、外部通信
+先の国別件数が `country_counts` フィールドに含まれます。
 
 ```bash
 python lan_security_check.py  # 自動検出されたサブネットを使用

--- a/lan_security_check.py
+++ b/lan_security_check.py
@@ -148,19 +148,23 @@ def check_external_comm(geoip_db: str = "GeoLite2-Country.mmdb") -> Dict[str, An
         except Exception:
             reader = None
     suspicious = []
+    country_counts: Dict[str, int] = {}
     for ip, _ in conns:
         country = geoip_country(reader, ip)
+        if country:
+            country_counts[country] = country_counts.get(country, 0) + 1
         if country in DANGER_COUNTRIES:
             suspicious.append({"ip": ip, "country": country})
     if reader:
         reader.close()
+    result: Dict[str, Any] = {"status": "ok", "country_counts": country_counts}
     if suspicious:
-        return {
+        result.update({
             "status": "warning",
             "connections": suspicious,
             "utm": ["web_filter"],
-        }
-    return {"status": "ok"}
+        })
+    return result
 
 def main() -> None:
     subnet = sys.argv[1] if len(sys.argv) > 1 else _SUBNET


### PR DESCRIPTION
## Summary
- enhance `lan_security_check.check_external_comm` to count countries
- show per-country counts in CLI JSON output
- document the new `country_counts` output
- test the external communication counting logic

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686b5797511c8323ba23b50e545cd948