### PR TITLE
Fix topology viewer dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   path: any
   http: ^1.4.0
   fl_chart: ^0.63.0
+  flutter_svg: ^2.0.7
 
 
 dev_dependencies:

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/result_page.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:io';
 
 void main() {
@@ -79,6 +80,6 @@ void main() {
     expect(find.text('トポロジ表示'), findsOneWidget);
     await tester.tap(find.text('トポロジ表示'));
     await tester.pumpAndSettle();
-    expect(find.byType(Image), findsOneWidget);
+    expect(find.byType(SvgPicture), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `flutter_svg` package for displaying SVG diagrams
- update test to expect `SvgPicture`

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686b4d9320a883238a105de00c594b91