### PR TITLE
Fix MaterialStateProperty usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -317,7 +317,7 @@ class _HomePageState extends State<HomePage> {
                   rows: [
                     for (final r in summary.results)
                       DataRow(
-                        color: WidgetStateProperty.all(
+                        color: MaterialStateProperty.all(
                           r.state == 'open'
                               ? ([23, 445].contains(r.port)
                                   ? Colors.redAccent
@@ -350,7 +350,7 @@ class _HomePageState extends State<HomePage> {
                   rows: [
                     for (final r in _reports)
                       DataRow(
-                        color: WidgetStateProperty.all(
+                        color: MaterialStateProperty.all(
                           _scoreColor(r.score),
                         ),
                         cells: [

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -315,7 +315,7 @@ class ResultPage extends StatelessWidget {
             rows: [
               for (final r in reports)
                 DataRow(
-                  color: WidgetStateProperty.all(
+                  color: MaterialStateProperty.all(
                     _scoreColor(r.score),
                   ),
                   cells: [


### PR DESCRIPTION
## Summary
- use `MaterialStateProperty` for DataTable row colors
- ensure `flutter_svg` dependency is present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b59a379948323ab10fcd3fce07c19