### PR TITLE
Add missing material import for tests

### DIFF
--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/main.dart';
 
 void main() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,6 +6,7 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 
 import 'package:nwc_densetsu/main.dart';
 


### PR DESCRIPTION
## Summary
- import `flutter/material.dart` in test files so widgets compile

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c97e1648323b7bcd591e6f13e0e