### PR TITLE
Fix DropdownButton analyzer imports

### DIFF
--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/main.dart';
 
 void main() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,6 +6,7 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
 
 import 'package:nwc_densetsu/main.dart';
 


### PR DESCRIPTION
## Summary
- add `flutter/material.dart` import in widget and main tests to recognize `DropdownButton`

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c8bd7548323bd1a3dab15584b7f