### PR TITLE
Fix generateTopologyDiagram import

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
-import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
+import 'package:nwc_densetsu/utils/report_utils.dart'
+    show generateTopologyDiagram;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 
@@ -169,7 +170,7 @@ class DiagnosticResultPage extends StatelessWidget {
   Future<void> _showTopology(BuildContext context) async {
     try {
       final generator = onGenerateTopology;
-      final path = await (generator ?? report_utils.generateTopologyDiagram)();
+      final path = await (generator ?? generateTopologyDiagram)();
       if (!context.mounted) return;
 
       final nodes = await _parseSvgNodes(path);


### PR DESCRIPTION
## Summary
- update `lib/result_page.dart` to import `generateTopologyDiagram` directly
- call `generateTopologyDiagram` without prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686bc0b5c8b08323a2aa5a8fb813b351