### PR TITLE
Enhance port status view

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -242,6 +242,7 @@ class _HomePageState extends State<HomePage> {
           securityScore: securityScore,
           riskScore: riskScore,
           items: items,
+          portSummaries: _scanResults,
         ),
       ),
     );

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -6,6 +6,13 @@ import 'package:nwc_densetsu/utils/report_utils.dart'
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 
+const Map<int, String> _dangerPortNotes = {
+  3389: 'リモートデスクトップ接続が可能なため、攻撃の対象になりやすい',
+  22: 'SSH 接続に使われ、ブルートフォース攻撃の標的となる恐れがあります',
+  23: 'Telnet 用ポートは平文通信のため非常に危険です',
+  445: 'ファイル共有(SMB)に利用され、マルウェア侵入経路となりえます',
+};
+
 class _SvgNode {
   final String label;
   final Rect rect;
@@ -30,6 +37,7 @@ class DiagnosticResultPage extends StatelessWidget {
   final int securityScore;
   final int riskScore;
   final List<DiagnosticItem> items;
+  final List<PortScanSummary> portSummaries;
   final Future<String> Function()? onGenerateTopology;
 
   const DiagnosticResultPage({
@@ -37,6 +45,7 @@ class DiagnosticResultPage extends StatelessWidget {
     required this.securityScore,
     required this.riskScore,
     required this.items,
+    this.portSummaries = const [],
     this.onGenerateTopology,
   });
 
@@ -146,6 +155,46 @@ class DiagnosticResultPage extends StatelessWidget {
     return nodes;
   }
 
+  Widget _portStatusSection() {
+    if (portSummaries.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('ポート開放状況',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 4),
+        const Text(
+          '特定のポートが開いていると、攻撃対象となる範囲が広がり、不正アクセスやマルウェア侵入の経路になる恐れがあります。',
+        ),
+        const SizedBox(height: 8),
+        for (final s in portSummaries) ...[
+          Text(s.host, style: const TextStyle(fontWeight: FontWeight.bold)),
+          Column(
+            children: [
+              for (final r in s.results)
+                Card(
+                  color: r.state == 'open'
+                      ? (_dangerPortNotes.containsKey(r.port)
+                          ? Colors.redAccent.withOpacity(0.2)
+                          : Colors.green.withOpacity(0.2))
+                      : Colors.grey.withOpacity(0.2),
+                  margin: const EdgeInsets.symmetric(vertical: 2),
+                  child: ListTile(
+                    title: Text(
+                        "${r.port}：${r.state == 'open' ? '危険（開いている）' : '安全（閉じている）'}"),
+                    subtitle: _dangerPortNotes[r.port] != null
+                        ? Text(_dangerPortNotes[r.port]!)
+                        : null,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+
   Future<void> _saveReport(BuildContext context) async {
     try {
       final result = await Process.run(
@@ -227,6 +276,8 @@ class DiagnosticResultPage extends StatelessWidget {
             _scoreSection('セキュリティスコア', securityScore),
             const SizedBox(height: 16),
             _scoreSection('リスクスコア', riskScore),
+            const SizedBox(height: 16),
+            _portStatusSection(),
             const SizedBox(height: 16),
             Expanded(
               child: ListView.builder(

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/result_page.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
 
 void main() {
   testWidgets('DiagnosticResultPage shows statuses and actions', (tester) async {
@@ -10,12 +11,19 @@ void main() {
       DiagnosticItem(name: 'C', description: 'd', status: 'danger', action: 'fix3'),
     ];
 
+    final summaries = [
+      const PortScanSummary('1.1.1.1', [
+        PortStatus(445, 'closed', 'smb'),
+        PortStatus(3389, 'open', 'rdp'),
+      ])
+    ];
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: DiagnosticResultPage(
           securityScore: 9,
           riskScore: 2,
           items: items,
+          portSummaries: summaries,
         ),
       ),
     );
@@ -32,5 +40,10 @@ void main() {
     expect(find.text('推奨対策: fix2'), findsOneWidget);
     expect(find.text('現状: danger'), findsOneWidget);
     expect(find.text('推奨対策: fix3'), findsOneWidget);
+
+    // Port status section
+    expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.textContaining('3389'), findsOneWidget);
+    expect(find.textContaining('危険'), findsOneWidget);
   });
 }

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -47,11 +47,12 @@ void main() {
     ];
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: DiagnosticResultPage(
           securityScore: 5,
           riskScore: 4,
           items: items,
+          portSummaries: const [],
         ),
       ),
     );
@@ -72,6 +73,7 @@ void main() {
           securityScore: 5,
           riskScore: 4,
           items: const [],
+          portSummaries: const [],
           onGenerateTopology: () async => imgFile.path,
         ),
       ),


### PR DESCRIPTION
## Summary
- highlight open ports in DiagnosticResultPage
- allow passing port scan results to results page
- show explanatory notes for risky ports
- update tests

## Testing
- `python -m unittest discover -s test` *(fails: ModuleNotFoundError: No module named 'graphviz')*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcd68b1f88323aeed5696d469ec14