### PR TITLE
Fix topology diagram import

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,8 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
-import 'package:nwc_densetsu/utils/report_utils.dart'
-    show generateTopologyDiagram;
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 
@@ -219,7 +218,7 @@ class DiagnosticResultPage extends StatelessWidget {
   Future<void> _showTopology(BuildContext context) async {
     try {
       final generator = onGenerateTopology;
-      final path = await (generator ?? generateTopologyDiagram)();
+      final path = await (generator ?? report_utils.generateTopologyDiagram)();
       if (!context.mounted) return;
 
       final nodes = await _parseSvgNodes(path);


### PR DESCRIPTION
## Summary
- fix call to generateTopologyDiagram by importing report_utils with a prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686bd1c4772883239c3a885a6760d9c2