### PR TITLE
Update port status display

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -180,7 +180,8 @@ class DiagnosticResultPage extends StatelessWidget {
                   margin: const EdgeInsets.symmetric(vertical: 2),
                   child: ListTile(
                     title: Text(
-                        "${r.port}：${r.state == 'open' ? '危険（開いている）' : '安全（閉じている）'}"),
+                      "${r.port} (${r.service})：${r.state == 'open' ? '危険（開いている）' : '安全（閉じている）'}",
+                    ),
                     subtitle: _dangerPortNotes[r.port] != null
                         ? Text(_dangerPortNotes[r.port]!)
                         : null,


### PR DESCRIPTION
## Summary
- show service names in port status cards

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd5a4831883238eb76751fd580183