### PR TITLE
Add external communication encryption status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ python lan_security_check.py  # 自動検出されたサブネットを使用
 python lan_security_check.py 10.0.0.0/24  # サブネットを指定する場合
 ```
 
+## 外部通信の暗号化状況
+
+`external_ip_report.py` を実行すると、現在の外部接続を確認し、HTTP や SMTP など暗号化されていない通信も含めて一覧表示できます。危険な通信は赤字で強調されます。
+
+```bash
+python external_ip_report.py
+```
+
+出力例:
+
+```
+宛先ドメイン\t通信プロトコル\t暗号化状況\t状態\tコメント
+example.com\tHTTPS\t暗号化\t安全\t
+mail.example\tSMTP\t非暗号化\t危険\t平文通信のため情報漏洩のリスクがあります
+```
+
 ## Network Topology
 
 `generate_topology.py` を使うと `discover_hosts.py` や `lan_port_scan.py` の JSON 出力からネットワーク図を生成できます。

--- a/external_ip_report.py
+++ b/external_ip_report.py
@@ -16,6 +16,27 @@ except ImportError:
 
 RED = "\033[31m"
 RESET = "\033[0m"
+GREEN = "\033[32m"
+
+# Map common ports to protocol names
+PORT_PROTOCOLS = {
+    20: "FTP",
+    21: "FTP",
+    22: "SSH",
+    23: "Telnet",
+    25: "SMTP",
+    80: "HTTP",
+    110: "POP3",
+    143: "IMAP",
+    443: "HTTPS",
+    465: "SMTPS",
+    563: "NNTPS",
+    587: "SMTP",
+    993: "IMAPS",
+    995: "POP3S",
+    989: "FTPS",
+    990: "FTPS",
+}
 
 ENCRYPTED_PORTS = {443, 22, 993, 995, 465, 563, 989, 990}
 UNENCRYPTED_PORTS = {80, 20, 21, 23, 25, 110, 143}
@@ -27,6 +48,16 @@ def classify_port(port: int) -> str:
     if port in UNENCRYPTED_PORTS:
         return "\u975e\u6697\u53f7\u5316"  # "非暗号化"
     return "\u4e0d\u660e"  # "不明"
+
+
+def protocol_name(port: int) -> str:
+    return PORT_PROTOCOLS.get(port, f"TCP/{port}")
+
+
+def risk_comment(port: int) -> str:
+    if port in UNENCRYPTED_PORTS:
+        return "平文通信のため情報漏洩のリスクがあります"
+    return ""
 
 
 def is_private(ip: str) -> bool:
@@ -70,7 +101,9 @@ def geoip_country(reader, ip: str) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="List external connections with domain and country")
+    parser = argparse.ArgumentParser(
+        description="List external connections with encryption status"
+    )
     parser.add_argument(
         "--geoip-db",
         default="GeoLite2-Country.mmdb",
@@ -100,11 +133,14 @@ def main():
     if reader:
         reader.close()
 
+    print("宛先ドメイン\t通信プロトコル\t暗号化状況\t状態\tコメント")
     for ip, domain, country, port, flag in results:
-        domain = domain or "(no PTR)"
-        country = country or ""
-        line = f"{ip}\t{domain}\t{country}\t{port}\t{flag}"
-        if flag == "\u975e\u6697\u53f7\u5316":
+        dest = domain or ip
+        proto = protocol_name(port)
+        state = "安全" if flag == "\u6697\u53f7\u5316" else "危険" if flag == "\u975e\u6697\u53f7\u5316" else "不明"
+        comment = risk_comment(port) if flag == "\u975e\u6697\u53f7\u5316" else ""
+        line = f"{dest}\t{proto}\t{flag}\t{state}\t{comment}"
+        if state == "危険":
             line = f"{RED}{line}{RESET}"
         print(line)
 


### PR DESCRIPTION
## Summary
- expand `external_ip_report.py` with protocol names and risk comments
- show table of dangerous plaintext connections
- document in README how to check external communication encryption status

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd84332e88323a6c95b7a3ecdeab9