### PR TITLE
Add device risk list UI

### DIFF
--- a/discover_hosts.py
+++ b/discover_hosts.py
@@ -90,14 +90,18 @@ def _run_nmap_scan(subnet):
         ip = None
         mac = ''
         vendor = ''
+        name = ''
         for addr in host.findall('address'):
             if addr.get('addrtype') == 'ipv4':
                 ip = addr.get('addr')
             elif addr.get('addrtype') == 'mac':
                 mac = addr.get('addr')
                 vendor = addr.get('vendor', '')
+        hn = host.find('hostnames/hostname')
+        if hn is not None:
+            name = hn.get('name', '')
         if ip:
-            results.append({'ip': ip, 'mac': mac, 'vendor': vendor})
+            results.append({'ip': ip, 'mac': mac, 'vendor': vendor, 'name': name})
     return results
 
 def _lookup_vendor(mac):

--- a/lib/device_list_page.dart
+++ b/lib/device_list_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:nwc_densetsu/network_scan.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
+
+class DeviceListPage extends StatelessWidget {
+  final List<NetworkDevice> devices;
+  final List<SecurityReport> reports;
+
+  const DeviceListPage({
+    super.key,
+    required this.devices,
+    required this.reports,
+  });
+
+  Color _scoreColor(int score) {
+    if (score >= 8) return Colors.redAccent;
+    if (score >= 5) return Colors.orange;
+    return Colors.green;
+  }
+
+  String _riskState(int score) {
+    if (score >= 8) return '危険';
+    if (score >= 5) return '注意';
+    return '安全';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <DataRow>[];
+    for (final d in devices) {
+      final rep =
+          reports.firstWhere((r) => r.ip == d.ip, orElse: () => const SecurityReport('', 0, [], [], '', openPorts: [], geoip: ''));
+      final status = _riskState(rep.score);
+      final comment = rep.risks.isNotEmpty ? rep.risks.first.description : '';
+      rows.add(
+        DataRow(
+          color: MaterialStateProperty.all(
+            _scoreColor(rep.score).withOpacity(0.2),
+          ),
+          cells: [
+            DataCell(Text(d.ip)),
+            DataCell(Text(d.mac)),
+            DataCell(Text(d.vendor)),
+            DataCell(Text(d.name)),
+            DataCell(Text(status)),
+            DataCell(Text(comment)),
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('LAN内デバイス一覧とリスクチェック')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'LAN内に接続されているすべての機器を可視化することで、不審なデバイスの存在に気付きやすくなります。知らない機器が接続されたまま放置されると、内部侵入や情報流出の温床になる可能性があります。',
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: DataTable(
+                  columns: const [
+                    DataColumn(label: Text('IPアドレス')),
+                    DataColumn(label: Text('MACアドレス')),
+                    DataColumn(label: Text('ベンダー名')),
+                    DataColumn(label: Text('機器名')),
+                    DataColumn(label: Text('状態')),
+                    DataColumn(label: Text('コメント')),
+                  ],
+                  rows: rows,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/port_constants.dart';
+import 'package:nwc_densetsu/device_list_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -248,6 +249,17 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  void _openDeviceListPage() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DeviceListPage(
+          devices: _devices,
+          reports: _reports,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -303,6 +315,13 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: _openResultPage,
               child: const Text('診断結果ページ'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _devices.isEmpty && _reports.isEmpty
+                  ? null
+                  : _openDeviceListPage,
+              child: const Text('LAN内デバイス一覧'),
             ),
             const SizedBox(height: 16),
             for (final summary in _scanResults) ...[

--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -7,8 +7,9 @@ class NetworkDevice {
   final String ip;
   final String mac;
   final String vendor;
+  final String name;
 
-  const NetworkDevice(this.ip, this.mac, this.vendor);
+  const NetworkDevice(this.ip, this.mac, this.vendor, [this.name = '']);
 }
 
 /// Runs the LAN discovery script and returns a list of devices.
@@ -32,6 +33,7 @@ Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}
           item['ip'] ?? '',
           item['mac'] ?? '',
           item['vendor'] ?? '',
+          item['name'] ?? item['hostname'] ?? '',
         ));
       }
     }

--- a/test/device_list_page_test.dart
+++ b/test/device_list_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/device_list_page.dart';
+import 'package:nwc_densetsu/network_scan.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
+
+void main() {
+  testWidgets('DeviceListPage shows devices and status', (tester) async {
+    const devices = [
+      NetworkDevice('1.1.1.1', 'AA:BB', 'V1', 'host1'),
+      NetworkDevice('2.2.2.2', 'CC:DD', 'V2', 'host2'),
+    ];
+    const reports = [
+      SecurityReport('1.1.1.1', 9, [RiskItem('r', 'c')], [], '',
+          openPorts: [], geoip: 'US'),
+      SecurityReport('2.2.2.2', 3, [], [], '', openPorts: [], geoip: 'JP'),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DeviceListPage(devices: devices, reports: reports),
+      ),
+    );
+
+    expect(find.text('1.1.1.1'), findsOneWidget);
+    expect(find.text('host1'), findsOneWidget);
+    expect(find.text('危険'), findsOneWidget);
+    expect(find.byType(DataRow), findsNWidgets(2));
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a DeviceListPage to show LAN devices with risk status
- extend `NetworkDevice` model with optional name field
- parse hostname from nmap output in `discover_hosts.py`
- expose button on main page to open the new list
- add tests for the new page

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd77c81d8832395c3a1fd784b78d5