### PR TITLE
Add GeoIP analysis page

### DIFF
--- a/lib/geoip_result_page.dart
+++ b/lib/geoip_result_page.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+const dangerCountries = {'CN', 'RU', 'KP'};
+const safeCountries = {'JP', 'US', 'GB', 'DE', 'FR', 'CA', 'AU'};
+
+Color _statusColor(String status) {
+  switch (status) {
+    case 'danger':
+      return Colors.redAccent;
+    case 'warning':
+      return Colors.orange;
+    default:
+      return Colors.green;
+  }
+}
+
+String _judgeStatus(String country) {
+  final code = country.toUpperCase();
+  if (dangerCountries.contains(code)) {
+    return 'danger';
+  }
+  if (safeCountries.contains(code)) {
+    return 'safe';
+  }
+  return 'warning';
+}
+
+class GeoipEntry {
+  final String ip;
+  final String domain;
+  final String country;
+
+  GeoipEntry(this.ip, this.domain, this.country);
+
+  String get status => _judgeStatus(country);
+
+  String get comment {
+    switch (status) {
+      case 'danger':
+        return '危険国との通信';
+      case 'warning':
+        return '未知の国への通信';
+      default:
+        return '';
+    }
+  }
+}
+
+class CountryCount {
+  final String country;
+  final int count;
+  CountryCount(this.country, this.count);
+
+  String get status => _judgeStatus(country);
+}
+
+class CountryCountChart extends StatelessWidget {
+  final List<CountryCount> counts;
+  const CountryCountChart({super.key, required this.counts});
+
+  @override
+  Widget build(BuildContext context) {
+    if (counts.isEmpty) return const SizedBox.shrink();
+    final groups = <BarChartGroupData>[];
+    for (var i = 0; i < counts.length; i++) {
+      final c = counts[i];
+      groups.add(
+        BarChartGroupData(x: i, barRods: [
+          BarChartRodData(toY: c.count.toDouble(), color: _statusColor(c.status))
+        ]),
+      );
+    }
+    return SizedBox(
+      height: 200,
+      child: BarChart(
+        BarChartData(
+          barGroups: groups,
+          titlesData: FlTitlesData(
+            topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            leftTitles: const AxisTitles(sideTitles: SideTitles(showTitles: true, interval: 1)),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  final idx = value.toInt();
+                  if (idx >= 0 && idx < counts.length) {
+                    return SideTitleWidget(
+                      axisSide: meta.axisSide,
+                      child: Text(counts[idx].country),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class GeoipResultPage extends StatelessWidget {
+  final List<GeoipEntry> entries;
+  const GeoipResultPage({super.key, required this.entries});
+
+  List<CountryCount> _buildCounts() {
+    final map = <String, int>{};
+    for (final e in entries) {
+      map[e.country] = (map[e.country] ?? 0) + 1;
+    }
+    final list = [for (final e in map.entries) CountryCount(e.key, e.value)];
+    list.sort((a, b) => b.count.compareTo(a.count));
+    return list;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final counts = _buildCounts();
+    return Scaffold(
+      appBar: AppBar(title: const Text('GeoIP解析：通信先の国別リスクチェック')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '通信先の国を解析することで、不審な地域との通信を検知できます。ロシア・中国・北朝鮮などとの通信がある場合、マルウェア感染や情報漏洩の兆候である可能性があります。',
+            ),
+            const SizedBox(height: 16),
+            CountryCountChart(counts: counts),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: entries.length,
+                itemBuilder: (context, idx) {
+                  final e = entries[idx];
+                  final color = _statusColor(e.status);
+                  return Card(
+                    color: color.withOpacity(0.2),
+                    child: ListTile(
+                      title: Text('${e.ip} (${e.domain})'),
+                      subtitle: Text('${e.country} - ${e.comment}'),
+                      leading: Icon(
+                        e.status == 'danger'
+                            ? Icons.error
+                            : e.status == 'warning'
+                                ? Icons.warning
+                                : Icons.check_circle,
+                        color: color,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/port_constants.dart';
+import 'package:nwc_densetsu/geoip_result_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -45,6 +46,17 @@ class _HomePageState extends State<HomePage> {
   final Map<String, int> _progress = {};
   static const int _taskCount = 3; // port, SSL, SPF
   double _overallProgress = 0.0;
+
+  void _openGeoipPage() {
+    final entries = [
+      GeoipEntry('93.184.216.34', 'example.com', 'US'),
+      GeoipEntry('203.0.113.1', 'mal.example', 'CN'),
+      GeoipEntry('198.51.100.2', '', 'RU'),
+    ];
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => GeoipResultPage(entries: entries)),
+    );
+  }
 
   List<int> get _selectedPorts {
     switch (_portPreset) {
@@ -303,6 +315,11 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: _openResultPage,
               child: const Text('診断結果ページ'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _openGeoipPage,
+              child: const Text('GeoIP解析ページ'),
             ),
             const SizedBox(height: 16),
             for (final summary in _scanResults) ...[


### PR DESCRIPTION
## Summary
- add `GeoipResultPage` widget for visualising GeoIP analysis results
- show bar chart of destination countries and detailed connection list
- add demo button to open the GeoIP page from the home screen

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd6823b108323a3198e9e03bddf0d