### PR TITLE
Add SSL certificate check table widget

### DIFF
--- a/lib/ssl_check_section.dart
+++ b/lib/ssl_check_section.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+/// SSL certificate check result entry.
+class SslCheckEntry {
+  final String domain;
+  final String issuer;
+  final String expiry;
+  final bool safe;
+  final String comment;
+
+  const SslCheckEntry({
+    required this.domain,
+    required this.issuer,
+    required this.expiry,
+    required this.safe,
+    required this.comment,
+  });
+}
+
+/// Section widget that displays SSL certificate diagnostics in a table.
+class SslCheckSection extends StatelessWidget {
+  final List<SslCheckEntry> results;
+
+  const SslCheckSection({super.key, required this.results});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'SSL証明書の安全性チェック',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'SSL証明書は通信の暗号化と正当性の証明に重要です。不正な証明書や期限切れの証明書は、盗聴やなりすまし攻撃のリスクにつながります。',
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('ドメイン名')),
+              DataColumn(label: Text('発行者')),
+              DataColumn(label: Text('有効期限')),
+              DataColumn(label: Text('状態')),
+              DataColumn(label: Text('コメント')),
+            ],
+            rows: [
+              for (final r in results)
+                DataRow(
+                  color: r.safe
+                      ? null
+                      : MaterialStateProperty.all(
+                          Colors.redAccent.withOpacity(0.1),
+                        ),
+                  cells: [
+                    DataCell(Text(r.domain)),
+                    DataCell(Text(r.issuer)),
+                    DataCell(Text(r.expiry)),
+                    DataCell(
+                      Text(
+                        r.safe ? '安全' : '危険',
+                        style: TextStyle(
+                          color: r.safe ? Colors.green : Colors.red,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    DataCell(Text(r.comment)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/ssl_check_section_test.dart
+++ b/test/ssl_check_section_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/ssl_check_section.dart';
+
+void main() {
+  testWidgets('SslCheckSection displays entries', (tester) async {
+    const items = [
+      SslCheckEntry(
+        domain: 'example.com',
+        issuer: 'CA',
+        expiry: '2025-01-01',
+        safe: true,
+        comment: '',
+      ),
+      SslCheckEntry(
+        domain: 'bad.example',
+        issuer: 'Unknown',
+        expiry: '2020-01-01',
+        safe: false,
+        comment: 'Expired certificate',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SslCheckSection(results: items),
+        ),
+      ),
+    );
+
+    expect(find.text('SSL証明書の安全性チェック'), findsOneWidget);
+    expect(find.text('example.com'), findsOneWidget);
+    expect(find.text('bad.example'), findsOneWidget);
+    expect(find.text('安全'), findsOneWidget);
+    expect(find.text('危険'), findsOneWidget);
+    expect(find.text('Expired certificate'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `SslCheckSection` widget to display SSL certificate diagnostics
- provide widget test for table rendering

## Testing
- `python -m unittest discover -s test` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_686bceea1d4083239da61d9a2b8848b9