### PR TITLE
Handle speedtest errors gracefully

### DIFF
--- a/network_speed.py
+++ b/network_speed.py
@@ -7,19 +7,25 @@ except ImportError:  # pragma: no cover - handled in tests
     speedtest = None
 
 
-def measure_speed() -> dict[str, float]:
+def measure_speed() -> dict[str, float] | None:
     if speedtest is None:
         raise RuntimeError("speedtest module not available")
-    st = speedtest.Speedtest()
-    st.get_best_server()
-    download = st.download()
-    upload = st.upload()
-    ping = st.results.ping
-    return {
-        "download": download / 1e6,  # Mbps
-        "upload": upload / 1e6,
-        "ping": float(ping),
-    }
+    try:
+        st = speedtest.Speedtest()
+        st.get_best_server()
+        download = st.download()
+        upload = st.upload()
+        ping = st.results.ping
+        return {
+            "download": download / 1e6,  # Mbps
+            "upload": upload / 1e6,
+            "ping": float(ping),
+        }
+    except speedtest.ConfigRetrievalError as e:
+        print(f"speedtest config error: {e}")
+    except Exception as e:
+        print(f"speedtest failed: {e}")
+    return None
 
 
 def main() -> None:

--- a/test/test_network_speed.py
+++ b/test/test_network_speed.py
@@ -17,5 +17,27 @@ class NetworkSpeedTest(unittest.TestCase):
         self.assertAlmostEqual(result['upload'], 20.0)
         self.assertEqual(result['ping'], 15.0)
 
+    @patch.object(network_speed, 'speedtest')
+    def test_measure_speed_config_error(self, mock_speedtest):
+        class DummyErr(Exception):
+            pass
+        mock_speedtest.ConfigRetrievalError = DummyErr
+        inst = MagicMock()
+        inst.get_best_server.side_effect = DummyErr('err')
+        mock_speedtest.Speedtest.return_value = inst
+        result = network_speed.measure_speed()
+        self.assertIsNone(result)
+
+    @patch.object(network_speed, 'speedtest')
+    def test_measure_speed_generic_error(self, mock_speedtest):
+        class DummyErr(Exception):
+            pass
+        mock_speedtest.ConfigRetrievalError = DummyErr
+        inst = MagicMock()
+        inst.get_best_server.side_effect = Exception('fail')
+        mock_speedtest.Speedtest.return_value = inst
+        result = network_speed.measure_speed()
+        self.assertIsNone(result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- catch speedtest exceptions in `network_speed.py`
- test error handling in `measure_speed`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bdca3e9b88323abb373d3ef3ab693