### PR TITLE
Add domain sender verification docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,38 @@ example.com\tHTTPS\t暗号化\t安全\t
 mail.example\tSMTP\t非暗号化\t危険\t平文通信のため情報漏洩のリスクがあります
 ```
 
+## ドメイン送信者認証チェック
+
+`verify_domain_sender.py` を使うと、指定したドメインの SPF レコードを取得して
+送信者認証が正しく設定されているか確認できます。オンライン環境では `nslookup`
+を利用し、オフライン時は `--offline` オプションで保存済みの DNS レコードを参照
+します。
+
+```bash
+python verify_domain_sender.py example.com
+```
+
+出力例:
+
+```json
+{"domain": "example.com", "record": "v=spf1 include:_spf.example.com ~all", "status": "safe", "comment": ""}
+```
+
+オフライン利用の例:
+
+```bash
+python verify_domain_sender.py example.com --offline offline_spf_records.json
+```
+
+`offline_spf_records.json` は次のようにドメインと SPF レコードの対応を記述します。
+
+```json
+{
+  "example.com": "v=spf1 include:_spf.example.com ~all",
+  "mail.test": "v=spf1 ip4:192.0.2.0/24 -all"
+}
+```
+
 ## Network Topology
 
 `generate_topology.py` を使うと `discover_hosts.py` や `lan_port_scan.py` の JSON 出力からネットワーク図を生成できます。

--- a/offline_spf_records.json
+++ b/offline_spf_records.json
@@ -1,0 +1,4 @@
+{
+  "example.com": "v=spf1 include:_spf.example.com ~all",
+  "mail.test": "v=spf1 ip4:192.0.2.0/24 -all"
+}

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+
+def lookup_spf(domain: str) -> str:
+    result = subprocess.run(['nslookup', '-type=txt', domain], capture_output=True, text=True)
+    for line in result.stdout.splitlines():
+        if 'v=spf1' in line:
+            return line.strip()
+    return ''
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Verify domain SPF record')
+    parser.add_argument('domain', help='Domain name to check')
+    parser.add_argument('--offline', help='Path to offline SPF record JSON file')
+    args = parser.parse_args()
+
+    record = ''
+    comment = ''
+
+    if args.offline:
+        try:
+            with open(args.offline, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            record = data.get(args.domain, '')
+            if record:
+                comment = 'offline record'
+        except Exception as e:
+            comment = f'failed to read offline file: {e}'
+
+    if not record:
+        try:
+            record = lookup_spf(args.domain)
+            if not record:
+                comment = 'No SPF record found'
+        except Exception as e:
+            comment = f'Failed to check SPF record: {e}'
+
+    status = 'safe' if record else 'danger'
+    result = {
+        'domain': args.domain,
+        'record': record,
+        'status': status,
+        'comment': comment,
+    }
+    print(json.dumps(result, ensure_ascii=False))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document how to verify sender SPF records
- add sample offline SPF data
- provide helper script for SPF checks

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be3d7f91c832380dea0552ad94c7e