### PR TITLE
Update SPF resolution for diagnostics

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -139,7 +139,9 @@ class _HomePageState extends State<HomePage> {
         });
         return value;
       });
-      final spfFuture = diag.checkSpfRecord(ip).then((value) {
+      final spfFuture = diag
+          .checkSpfRecord(d.name.isNotEmpty ? d.name : ip)
+          .then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;
           completedTasks++;


### PR DESCRIPTION
## Summary
- resolve hostname in `analyzeHost` before checking SPF
- pass discovered hostname to `checkSpfRecord`

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be3d6c12c8323946e6cf38cf93cf5