### PR TITLE
Add offline DNS TXT record helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ pip install -r requirements.txt
   - DNS の SPF レコード
     - 診断結果ページでは各ドメインの SPF レコードを表形式で表示します。
       未設定 (danger) は赤色、取得エラー (warning) は黄色でハイライトされます。
+    - ネットワークからの取得ができない場合は、BIND ゾーンファイルや
+      `dig` の出力を保存したテキストを `--zone-file` に指定して
+      オフラインで参照できます。各行は `example.com. IN TXT "v=spf1 +mx -all"`
+      のように TXT レコードを記述してください。
   - ネットワーク速度測定 (download/upload/ping) の結果表示
   - これらを基にしたセキュリティスコア（0〜10）
 
@@ -103,6 +107,12 @@ nmap -V # または arp-scan --version
 ```
 
 表示されない場合はインストール先を PATH に追加してください。
+
+## DNS TXT レコードをファイルから取得する
+
+オフライン環境では `dns_records.py` に用意した `--zone-file` オプションを利用し、
+SPF/DKIM/DMARC の TXT レコードをゾーンファイルから読み取れます。BIND 形式や
+`dig example.com TXT` を保存したテキストを指定してください。
 
 
 ## LAN + Port Scan

--- a/dns_records.py
+++ b/dns_records.py
@@ -1,0 +1,73 @@
+import re
+import subprocess
+from typing import Optional
+
+
+def _query_txt(name: str) -> str:
+    """Query TXT record for name using nslookup."""
+    try:
+        proc = subprocess.run(
+            ["nslookup", "-type=txt", name], capture_output=True, text=True, timeout=5
+        )
+        if proc.returncode != 0:
+            return ""
+        for line in proc.stdout.splitlines():
+            m = re.search(r'"([^"]+)"', line)
+            if m:
+                return m.group(1)
+    except Exception:
+        pass
+    return ""
+
+
+def _find_in_file(path: str, name: str) -> str:
+    """Return the first TXT record for name found in file."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                if name in line and "TXT" in line.upper():
+                    m = re.search(r'"([^"]+)"', line)
+                    if m:
+                        return m.group(1)
+    except Exception:
+        pass
+    return ""
+
+
+def get_spf_record(domain: str, records_file: Optional[str] = None) -> str:
+    """Return SPF record for domain."""
+    name = domain
+    if records_file:
+        return _find_in_file(records_file, name)
+    return _query_txt(name)
+
+
+def get_dkim_record(domain: str, selector: str = "default", records_file: Optional[str] = None) -> str:
+    """Return DKIM record for selector._domainkey.domain."""
+    name = f"{selector}._domainkey.{domain}"
+    if records_file:
+        return _find_in_file(records_file, name)
+    return _query_txt(name)
+
+
+def get_dmarc_record(domain: str, records_file: Optional[str] = None) -> str:
+    """Return DMARC record for _dmarc.domain."""
+    name = f"_dmarc.{domain}"
+    if records_file:
+        return _find_in_file(records_file, name)
+    return _query_txt(name)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Retrieve DNS TXT records")
+    parser.add_argument("domain", help="Domain to query")
+    parser.add_argument("--selector", default="default", help="DKIM selector")
+    parser.add_argument("--zone-file", help="Path to zone file for offline mode")
+    args = parser.parse_args()
+
+    spf = get_spf_record(args.domain, records_file=args.zone_file)
+    dkim = get_dkim_record(args.domain, selector=args.selector, records_file=args.zone_file)
+    dmarc = get_dmarc_record(args.domain, records_file=args.zone_file)
+    print({"spf": spf, "dkim": dkim, "dmarc": dmarc})

--- a/test/sample_zone.txt
+++ b/test/sample_zone.txt
@@ -1,0 +1,3 @@
+example.com. IN TXT "v=spf1 +mx -all"
+default._domainkey.example.com. IN TXT "v=DKIM1; k=rsa; p=abcd"
+_dmarc.example.com. IN TXT "v=DMARC1; p=none"

--- a/test/test_dns_records.py
+++ b/test/test_dns_records.py
@@ -1,0 +1,21 @@
+import unittest
+from dns_records import get_spf_record, get_dkim_record, get_dmarc_record
+
+class DnsRecordFileTest(unittest.TestCase):
+    def setUp(self):
+        self.zone = 'test/sample_zone.txt'
+
+    def test_spf_from_file(self):
+        rec = get_spf_record('example.com', records_file=self.zone)
+        self.assertEqual(rec, 'v=spf1 +mx -all')
+
+    def test_dkim_from_file(self):
+        rec = get_dkim_record('example.com', selector='default', records_file=self.zone)
+        self.assertEqual(rec, 'v=DKIM1; k=rsa; p=abcd')
+
+    def test_dmarc_from_file(self):
+        rec = get_dmarc_record('example.com', records_file=self.zone)
+        self.assertEqual(rec, 'v=DMARC1; p=none')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow SPF/DKIM/DMARC checks to read from a zone file when network queries are blocked
- document offline usage in README
- add unit tests for file-based TXT lookup

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686be3d6b85c832382abde4cb1c32c9a