### PR TITLE
Enable pytest from test directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,14 @@ python generate_topology.py scan_results.json -o topology.svg
 ## テスト
 
 Python スクリプトのユニットテストは `test` ディレクトリにあります。すべて実行する
-場合は以下のコマンドを使用します。
+場合は `pytest` を利用します。
 
 ```bash
-python -m unittest discover -s test
+pytest
 ```
+
+`test` ディレクトリで `pytest` を実行しても動作するよう、`conftest.py` で
+`PYTHONPATH` を調整しています。
 
 Flutter ウィジェットテストを実行するには次のコマンドを利用します。
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"Root package for NWCD project"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- make repository root a package so modules are discoverable
- add `conftest.py` to adjust `PYTHONPATH` when running pytest from `test`
- document pytest usage in README

## Testing
- `pytest -q`
- `(cd test && pytest -q)`

------
https://chatgpt.com/codex/tasks/task_e_686be720b7888323b5e15f431fd61395