### PR TITLE
Add vendorWidgetStateProperty getter

### DIFF
--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -8,6 +8,9 @@ class NetworkDevice {
   final String mac;
   final String vendor;
 
+  /// Convenience getter mirroring [vendor] for widget state bindings.
+  String get vendorWidgetStateProperty => vendor;
+
   const NetworkDevice(this.ip, this.mac, this.vendor);
 }
 


### PR DESCRIPTION
## Summary
- add `vendorWidgetStateProperty` getter to `NetworkDevice`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_686c63a180008323a6a155403b9535ea