### PR TITLE
Add Python helper for topology diagram

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -1,5 +1,10 @@
 from typing import Iterable, List
 
+import json
+from pathlib import Path
+
+import generate_topology
+
 from common_constants import DANGER_COUNTRIES
 
 
@@ -13,4 +18,31 @@ def calc_utm_items(score: int, open_ports: Iterable[str], countries: Iterable[st
     if score >= 5:
         items.add("ips")
     return sorted(items)
+
+
+def generate_topology_diagram(input_path: str, output: str = "topology.svg") -> str:
+    """Create a network topology diagram from scan results.
+
+    Parameters
+    ----------
+    input_path: str
+        Path to JSON produced by ``discover_hosts.py`` or ``lan_port_scan.py``.
+    output: str
+        Output file path. Extension determines format (.png/.svg/.dot).
+
+    Returns
+    -------
+    str
+        The path to the generated diagram.
+    """
+    with open(input_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    graph = generate_topology.build_graph(data)
+    generate_topology.save_graph(graph, output)
+    return str(Path(output))
+
+
+# Allow camelCase name for compatibility with Dart code expectations.
+generateTopologyDiagram = generate_topology_diagram
 

--- a/test/test_report_utils.py
+++ b/test/test_report_utils.py
@@ -1,0 +1,40 @@
+import unittest
+import json
+from pathlib import Path
+import tempfile
+
+from report_utils import generate_topology_diagram, generateTopologyDiagram
+
+
+class ReportUtilsGenerateTopologyTest(unittest.TestCase):
+    def test_generate_topology_diagram_creates_file(self):
+        data = {"hosts": [{"ip": "192.168.1.2"}]}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "scan.json"
+            output_path = Path(tmpdir) / "out.dot"
+            with open(input_path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+
+            result = generate_topology_diagram(str(input_path), str(output_path))
+
+            self.assertEqual(result, str(output_path))
+            self.assertTrue(output_path.exists())
+            self.assertGreater(output_path.stat().st_size, 0)
+
+    def test_generateTopologyDiagram_alias(self):
+        data = {"hosts": []}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "scan.json"
+            output_path = Path(tmpdir) / "alias.dot"
+            with open(input_path, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+
+            result = generateTopologyDiagram(str(input_path), str(output_path))
+
+            self.assertEqual(result, str(output_path))
+            self.assertTrue(output_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- expose a `generate_topology_diagram` function in `report_utils.py`
- alias it as `generateTopologyDiagram` for compatibility
- test the new helper

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c640ab8e483239503f440d8805f86