### PR TITLE
Add DKIM selector lookup

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -260,20 +260,47 @@ Future<SpfResult> checkSpfRecord(String domain) async {
 }
 
 /// Checks DKIM TXT record either via `nslookup` or from a local file.
-Future<bool> checkDkimRecord(String domain, {String? filePath}) async {
+///
+/// [selectors] specifies the DKIM selectors to try in order. The first record
+/// containing `v=DKIM1` will result in `true` being returned.
+Future<bool> checkDkimRecord(
+  String domain, {
+  String? filePath,
+  List<String> selectors = const ['default', 'google', 'selector1'],
+}) async {
   try {
-    String output;
+    final lines = <String>[];
     if (filePath != null) {
-      output = await File(filePath).readAsString();
-    } else {
-      final result = await Process.run('nslookup', ['-type=txt', domain]);
-      output = result.stdout.toString();
+      final text = await File(filePath).readAsString();
+      lines.addAll(text.split('\n'));
     }
-    for (final line in output.split('\n')) {
-      if (line.toLowerCase().contains('v=dkim1')) {
-        return true;
+
+    for (final selector in selectors) {
+      final query = '$selector._domainkey.$domain';
+
+      String output;
+      if (filePath != null) {
+        // Try to find a matching line in the provided file first.
+        for (final line in lines) {
+          if (line.contains(query) &&
+              line.toLowerCase().contains('v=dkim1')) {
+            return true;
+          }
+        }
+        // Fall back to searching the whole file for v=DKIM1.
+        output = lines.join('\n');
+      } else {
+        final result = await Process.run('nslookup', ['-type=txt', query]);
+        output = result.stdout.toString();
+      }
+
+      for (final line in output.split('\n')) {
+        if (line.toLowerCase().contains('v=dkim1')) {
+          return true;
+        }
       }
     }
+
     return false;
   } catch (_) {
     return false;

--- a/test/dkim_dmarc_test.dart
+++ b/test/dkim_dmarc_test.dart
@@ -3,10 +3,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/diagnostics.dart' as diag;
 
 void main() {
-  test('checkDkimRecord parses file', () async {
+  test('checkDkimRecord tries selectors', () async {
     final file = File('${Directory.systemTemp.path}/dkim.txt');
-    await file.writeAsString('v=DKIM1; k=rsa');
-    final ok = await diag.checkDkimRecord('example.com', filePath: file.path);
+    await file.writeAsString(
+        'google._domainkey.example.com. IN TXT "v=DKIM1; k=rsa"');
+    final ok = await diag.checkDkimRecord(
+      'example.com',
+      filePath: file.path,
+      selectors: ['default', 'google'],
+    );
     expect(ok, isTrue);
     await file.delete();
   });


### PR DESCRIPTION
## Summary
- support multiple DKIM selectors when checking DNS
- update DKIM tests for selector behaviour

## Testing
- `PYTHONPATH=. pytest test/test_dns_records.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c777d2f408323bb334fa50738fa04