### PR TITLE
Fix domain handling for mail record checks

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -389,13 +389,13 @@ Future<SecurityReport> runSecurityReport({
 Future<SecurityReport> analyzeHost(
   String ip, {
   List<int>? ports,
-  String? domain,
+  required String domain,
 }) async {
   final portSummary = await scanPorts(ip, ports);
   final sslRes = await checkSslCertificate(ip);
-  final spfRes = await checkSpfRecord(ip);
-  final dkimValid = await checkDkimRecord(ip);
-  final dmarcValid = await checkDmarcRecord(ip);
+  final spfRes = await checkSpfRecord(domain);
+  final dkimValid = await checkDkimRecord(domain);
+  final dmarcValid = await checkDmarcRecord(domain);
   final report = await runSecurityReport(
     ip: ip,
     openPorts: [for (final p in portSummary.results)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -142,9 +142,8 @@ class _HomePageState extends State<HomePage> {
         });
         return value;
       });
-      final spfFuture = diag
-          .checkSpfRecord(d.name.isNotEmpty ? d.name : ip)
-          .then((value) {
+      final domain = d.name.isNotEmpty ? d.name : ip;
+      final spfFuture = diag.checkSpfRecord(domain).then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;
           completedTasks++;
@@ -153,7 +152,7 @@ class _HomePageState extends State<HomePage> {
         });
         return value;
       });
-      final dkimFuture = diag.checkDkimRecord(ip).then((value) {
+      final dkimFuture = diag.checkDkimRecord(domain).then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;
           completedTasks++;
@@ -162,7 +161,8 @@ class _HomePageState extends State<HomePage> {
         });
         return value;
       });
-      final dmarcFuture = diag.checkDmarcRecord(ip).then((value) {
+      final dmarcDomain = domain.startsWith('_dmarc.') ? domain : '_dmarc.$domain';
+      final dmarcFuture = diag.checkDmarcRecord(dmarcDomain).then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;
           completedTasks++;


### PR DESCRIPTION
## Summary
- pass device names as domain when running SPF/DKIM/DMARC lookups
- make `analyzeHost` require a domain and use it for the record checks

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c77799cf88323a8b1d0cd5e564565