### PR TITLE
Show LAN devices in diagnostic results

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -300,6 +300,8 @@ class _HomePageState extends State<HomePage> {
           items: items,
           portSummaries: _scanResults,
           spfResults: _spfResults,
+          devices: _devices,
+          reports: _reports,
           defenderEnabled: _defense?.defenderEnabled,
           firewallEnabled: _defense?.firewallEnabled,
         ),

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
+import 'package:nwc_densetsu/device_list_page.dart';
+import 'package:nwc_densetsu/network_scan.dart' show NetworkDevice;
 import 'package:nwc_densetsu/utils/report_utils.dart'
     show generateTopologyDiagram;
 import 'package:flutter_svg/flutter_svg.dart';
@@ -39,6 +41,8 @@ class DiagnosticResultPage extends StatelessWidget {
   final List<DiagnosticItem> items;
   final List<PortScanSummary> portSummaries;
   final List<SpfResult> spfResults;
+  final List<NetworkDevice> devices;
+  final List<SecurityReport> reports;
   final bool? defenderEnabled;
   final bool? firewallEnabled;
   final Future<String> Function()? onGenerateTopology;
@@ -50,6 +54,8 @@ class DiagnosticResultPage extends StatelessWidget {
     required this.items,
     this.portSummaries = const [],
     this.spfResults = const [],
+    this.devices = const [],
+    this.reports = const [],
     this.defenderEnabled,
     this.firewallEnabled,
     this.onGenerateTopology,
@@ -197,6 +203,66 @@ class DiagnosticResultPage extends StatelessWidget {
           ),
           const SizedBox(height: 8),
         ],
+      ],
+    );
+  }
+
+  Color _deviceScoreColor(int score) {
+    if (score >= 8) return Colors.redAccent;
+    if (score >= 5) return Colors.orange;
+    return Colors.green;
+  }
+
+  String _deviceRiskState(int score) {
+    if (score >= 8) return '危険';
+    if (score >= 5) return '注意';
+    return '安全';
+  }
+
+  Widget _lanDevicesSection(BuildContext context) {
+    if (devices.isEmpty) return const SizedBox.shrink();
+    final rows = <DataRow>[];
+    for (final d in devices) {
+      final rep = reports.firstWhere((r) => r.ip == d.ip,
+          orElse: () => const SecurityReport('', 0, [], [], '',
+              openPorts: [], geoip: ''));
+      rows.add(
+        DataRow(
+          color: MaterialStateProperty.all(
+            _deviceScoreColor(rep.score).withOpacity(0.2),
+          ),
+          cells: [
+            DataCell(Text(d.ip)),
+            DataCell(Text(d.mac)),
+            DataCell(Text(d.vendor)),
+            DataCell(Text(d.name)),
+            DataCell(Text(_deviceRiskState(rep.score))),
+            DataCell(Text(rep.risks.isNotEmpty ? rep.risks.first.description : '')),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('LAN内デバイス一覧',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('IPアドレス')),
+              DataColumn(label: Text('MACアドレス')),
+              DataColumn(label: Text('ベンダー名')),
+              DataColumn(label: Text('機器名')),
+              DataColumn(label: Text('状態')),
+              DataColumn(label: Text('コメント')),
+            ],
+            rows: rows,
+          ),
+        ),
       ],
     );
   }
@@ -396,6 +462,8 @@ class DiagnosticResultPage extends StatelessWidget {
             _scoreSection('リスクスコア', riskScore),
             const SizedBox(height: 16),
             _portStatusSection(),
+            const SizedBox(height: 16),
+            _lanDevicesSection(context),
             const SizedBox(height: 16),
             _spfSection(),
             const SizedBox(height: 16),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
+import 'package:nwc_densetsu/network_scan.dart';
 
 void main() {
   testWidgets('DiagnosticResultPage shows statuses and actions', (tester) async {
@@ -17,6 +18,13 @@ void main() {
         PortStatus(3389, 'open', 'rdp'),
       ])
     ];
+    const devices = [
+      NetworkDevice('1.1.1.1', 'AA:BB', 'V1', 'host1'),
+    ];
+    const reports = [
+      SecurityReport('1.1.1.1', 9, [RiskItem('r', 'c')], [], '',
+          openPorts: [], geoip: 'US'),
+    ];
     await tester.pumpWidget(
       MaterialApp(
         home: DiagnosticResultPage(
@@ -24,6 +32,8 @@ void main() {
           riskScore: 2,
           items: items,
           portSummaries: summaries,
+          devices: devices,
+          reports: reports,
         ),
       ),
     );
@@ -45,5 +55,9 @@ void main() {
     expect(find.text('ポート開放状況'), findsOneWidget);
     expect(find.textContaining('3389'), findsOneWidget);
     expect(find.textContaining('危険'), findsOneWidget);
+
+    // LAN devices section
+    expect(find.text('host1'), findsOneWidget);
+    expect(find.byType(DataRow), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- show LAN device details on `DiagnosticResultPage`
- pass device and report data when opening result page
- test that LAN devices appear in diagnostic results

## Testing
- `python -m pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c77c59d108323805d2c8e7caed1f4