### PR TITLE
Remove unused calc_risk_score_v2 alias

### DIFF
--- a/risk_score.py
+++ b/risk_score.py
@@ -13,7 +13,7 @@ UNKNOWN_PORT_POINTS = 0.5
 PORT_SCORE_CAP = 6.0
 COUNTRY_SCORE_CAP = 4.0
 
-__all__ = ["calc_risk_score", "calc_risk_score_v2"]
+__all__ = ["calc_risk_score"]
 
 PORT_SCORES = {
     "3389": 4.0,  # RDP
@@ -66,8 +66,6 @@ def calc_risk_score(
     return round(score, 1), warnings
 
 
-# Backwards compatibility
-calc_risk_score_v2 = calc_risk_score
 
 def main():
     """Read device data from a JSON file and print each device's risk score.


### PR DESCRIPTION
## Summary
- remove `calc_risk_score_v2` alias
- export only `calc_risk_score` from `risk_score.py`
- keep tests using `calc_risk_score`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c788e41b8832392c819b3114dd769