### PR TITLE
Add dns_records integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ nmap -V # または arp-scan --version
 SPF/DKIM/DMARC の TXT レコードをゾーンファイルから読み取れます。BIND 形式や
 `dig example.com TXT` を保存したテキストを指定してください。
 
+### ゾーンファイル形式
+
+`dns_records.py` が参照するファイルは以下のような簡易 BIND 形式です。1 行に 1
+レコードを記述し、TXT レコードのみを対象とします。
+
+```
+example.com.                     IN TXT "v=spf1 +mx -all"
+default._domainkey.example.com.  IN TXT "v=DKIM1; k=rsa; p=abcd"
+_dmarc.example.com.              IN TXT "v=DMARC1; p=none"
+```
+
+先頭のドメイン名、`IN TXT`, 値という順番で記載してください。その他の行は無視されます。
+
 
 ## LAN + Port Scan
 

--- a/dns_records.py
+++ b/dns_records.py
@@ -1,3 +1,4 @@
+import json
 import re
 import subprocess
 from typing import Optional
@@ -68,6 +69,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     spf = get_spf_record(args.domain, records_file=args.zone_file)
-    dkim = get_dkim_record(args.domain, selector=args.selector, records_file=args.zone_file)
+    dkim = get_dkim_record(
+        args.domain, selector=args.selector, records_file=args.zone_file
+    )
     dmarc = get_dmarc_record(args.domain, records_file=args.zone_file)
-    print({"spf": spf, "dkim": dkim, "dmarc": dmarc})
+    print(json.dumps({"spf": spf, "dkim": dkim, "dmarc": dmarc}))

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -242,61 +242,67 @@ Future<SslResult> checkSslCertificate(String host) async {
   }
 }
 
-/// Retrieves the SPF record for the given domain using `nslookup`.
-Future<SpfResult> checkSpfRecord(String domain) async {
+/// Retrieves the SPF record for the given domain. When [recordsFile] is
+/// supplied, the TXT record is looked up offline via `dns_records.py`.
+Future<SpfResult> checkSpfRecord(String domain, {String? recordsFile}) async {
+  const script = 'dns_records.py';
+  final args = <String>[script, domain];
+  if (recordsFile != null) {
+    args.addAll(['--zone-file', recordsFile]);
+  }
   try {
-    final result = await Process.run('nslookup', ['-type=txt', domain]);
-    final output = result.stdout.toString();
-    final lines = output.split('\n');
-    for (final line in lines) {
-      if (line.contains('v=spf1')) {
-        return SpfResult(domain, line.trim(), 'safe', '');
-      }
+    final result = await Process.run('python', args);
+    if (result.exitCode != 0) {
+      throw result.stderr.toString();
     }
-    return SpfResult(domain, '', 'danger', 'No SPF record found');
+    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final record = data['spf']?.toString() ?? '';
+    if (record.isEmpty) {
+      return SpfResult(domain, '', 'danger', 'No SPF record found');
+    }
+    return SpfResult(domain, record, 'safe', '');
   } catch (e) {
     return SpfResult(domain, '', 'warning', 'Failed to check SPF record: $e');
   }
 }
 
-/// Checks DKIM TXT record either via `nslookup` or from a local file.
-Future<bool> checkDkimRecord(String domain, {String? filePath}) async {
+/// Checks DKIM TXT record either online or from a zone file via `dns_records.py`.
+Future<bool> checkDkimRecord(String domain,
+    {String selector = 'default', String? recordsFile}) async {
+  const script = 'dns_records.py';
+  final args = <String>[script, domain, '--selector', selector];
+  if (recordsFile != null) {
+    args.addAll(['--zone-file', recordsFile]);
+  }
   try {
-    String output;
-    if (filePath != null) {
-      output = await File(filePath).readAsString();
-    } else {
-      final result = await Process.run('nslookup', ['-type=txt', domain]);
-      output = result.stdout.toString();
+    final result = await Process.run('python', args);
+    if (result.exitCode != 0) {
+      throw result.stderr.toString();
     }
-    for (final line in output.split('\n')) {
-      if (line.toLowerCase().contains('v=dkim1')) {
-        return true;
-      }
-    }
-    return false;
+    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final record = data['dkim']?.toString() ?? '';
+    return record.toLowerCase().contains('v=dkim1');
   } catch (_) {
     return false;
   }
 }
 
-/// Checks DMARC TXT record either via `nslookup` or from a local file.
-Future<bool> checkDmarcRecord(String domain, {String? filePath}) async {
-  final dmarcDomain = domain.startsWith('_dmarc.') ? domain : '_dmarc.$domain';
+/// Checks DMARC TXT record either online or from a zone file using
+/// `dns_records.py`.
+Future<bool> checkDmarcRecord(String domain, {String? recordsFile}) async {
+  const script = 'dns_records.py';
+  final args = <String>[script, domain];
+  if (recordsFile != null) {
+    args.addAll(['--zone-file', recordsFile]);
+  }
   try {
-    String output;
-    if (filePath != null) {
-      output = await File(filePath).readAsString();
-    } else {
-      final result = await Process.run('nslookup', ['-type=txt', dmarcDomain]);
-      output = result.stdout.toString();
+    final result = await Process.run('python', args);
+    if (result.exitCode != 0) {
+      throw result.stderr.toString();
     }
-    for (final line in output.split('\n')) {
-      if (line.toLowerCase().contains('v=dmarc1')) {
-        return true;
-      }
-    }
-    return false;
+    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final record = data['dmarc']?.toString() ?? '';
+    return record.toLowerCase().contains('v=dmarc1');
   } catch (_) {
     return false;
   }

--- a/test/test_dns_records.py
+++ b/test/test_dns_records.py
@@ -1,4 +1,6 @@
 import unittest
+import json
+import subprocess
 from dns_records import get_spf_record, get_dkim_record, get_dmarc_record
 
 class DnsRecordFileTest(unittest.TestCase):
@@ -16,6 +18,18 @@ class DnsRecordFileTest(unittest.TestCase):
     def test_dmarc_from_file(self):
         rec = get_dmarc_record('example.com', records_file=self.zone)
         self.assertEqual(rec, 'v=DMARC1; p=none')
+
+    def test_cli_zone_file(self):
+        proc = subprocess.run(
+            ['python', 'dns_records.py', 'example.com', '--zone-file', self.zone],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(proc.stdout)
+        self.assertEqual(data['spf'], 'v=spf1 +mx -all')
+        self.assertEqual(data['dkim'], 'v=DKIM1; k=rsa; p=abcd')
+        self.assertEqual(data['dmarc'], 'v=DMARC1; p=none')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- delegate TXT lookups to dns_records.py
- support --zone-file for SPF/DKIM/DMARC helpers
- output JSON from dns_records CLI
- document zone-file format in README
- test dns_records CLI offline mode

## Testing
- `python -m unittest discover -v test`

------
https://chatgpt.com/codex/tasks/task_e_686c777f3a7c8323abbc68743425b5c2