### PR TITLE
Share color constants across modules

### DIFF
--- a/common_constants.py
+++ b/common_constants.py
@@ -3,3 +3,7 @@
 DANGER_COUNTRIES = {"RU", "CN", "KP"}  # Russia, China, North Korea
 
 SAFE_COUNTRIES = {"JP", "US", "GB", "DE", "FR", "CA", "AU"}
+
+# ANSI color escape sequences for console output.
+RED = "\033[31m"
+RESET = "\033[0m"

--- a/external_ip_report.py
+++ b/external_ip_report.py
@@ -14,8 +14,7 @@ except ImportError:
     geoip2 = None
 
 
-RED = "\033[31m"
-RESET = "\033[0m"
+from common_constants import RED, RESET
 
 ENCRYPTED_PORTS = {443, 22, 993, 995, 465, 563, 989, 990}
 UNENCRYPTED_PORTS = {80, 20, 21, 23, 25, 110, 143}

--- a/risk_score.py
+++ b/risk_score.py
@@ -3,7 +3,12 @@
 import json
 import sys
 
-from common_constants import DANGER_COUNTRIES, SAFE_COUNTRIES
+from common_constants import (
+    DANGER_COUNTRIES,
+    SAFE_COUNTRIES,
+    RED,
+    RESET,
+)
 
 
 # Score added when encountering an unknown port.
@@ -26,8 +31,6 @@ PORT_SCORES = {
 }
 
 
-RED = "\033[31m"
-RESET = "\033[0m"
 
 
 def calc_risk_score(


### PR DESCRIPTION
## Summary
- add `RED` and `RESET` to `common_constants`
- use these constants from `risk_score` and `external_ip_report`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c788e1b1083238a6a27e28df1e38b