### PR TITLE
Add external communication report

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,11 @@ python lan_security_check.py 10.0.0.0/24  # サブネットを指定する場合
 
 ## 外部通信の暗号化状況
 
-`external_ip_report.py` を実行すると、現在の外部接続を確認し、HTTP や SMTP など暗号化されていない通信も含めて一覧表示できます。危険な通信は赤字で強調されます。
+`external_ip_report.py` を実行すると、現在の外部接続を確認し、HTTP や SMTP など暗号化されていない通信も含めて一覧表示できます。危険な通信は赤字で強調されます。`--json` オプションを付けると結果を JSON 形式で取得できます。
 
 ```bash
 python external_ip_report.py
+python external_ip_report.py --json
 ```
 
 出力例:
@@ -267,6 +268,7 @@ example.com\tHTTPS\t暗号化\t安全\t
 mail.example\tSMTP\t非暗号化\t危険\t平文通信のため情報漏洩のリスクがあります
 ```
 
+LAN スキャン後の診断結果ページでは、このレポートを取り込み「外部通信の暗号化状況」として表形式で表示されます。
 ## ドメイン送信者認証チェック
 
 `verify_domain_sender.py` を使うと、指定したドメインの SPF レコードを取得して

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ class _HomePageState extends State<HomePage> {
   List<NetworkDevice> _devices = <NetworkDevice>[];
   List<SecurityReport> _reports = [];
   List<SpfResult> _spfResults = [];
+  List<diag.ExternalCommEntry> _externalComms = [];
   diag.NetworkSpeed? _speed;
   diag.DefenseStatus? _defense;
   bool _lanScanning = false;
@@ -79,6 +80,7 @@ class _HomePageState extends State<HomePage> {
       _scanResults = [];
       _reports = [];
       _spfResults = [];
+      _externalComms = [];
       _speed = null;
       _output = '診断中...\n';
       _progress.clear();
@@ -89,6 +91,8 @@ class _HomePageState extends State<HomePage> {
     setState(() => _speed = speed);
     final defense = await diag.checkDefenseStatus();
     setState(() => _defense = defense);
+    final comms = await diag.runExternalCommReport();
+    setState(() => _externalComms = comms);
     final buffer = StringBuffer();
     if (speed != null) {
       buffer.writeln('--- Network Speed ---');
@@ -300,6 +304,7 @@ class _HomePageState extends State<HomePage> {
           items: items,
           portSummaries: _scanResults,
           spfResults: _spfResults,
+          externalComms: _externalComms,
           defenderEnabled: _defense?.defenderEnabled,
           firewallEnabled: _defense?.firewallEnabled,
         ),

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -39,6 +39,7 @@ class DiagnosticResultPage extends StatelessWidget {
   final List<DiagnosticItem> items;
   final List<PortScanSummary> portSummaries;
   final List<SpfResult> spfResults;
+  final List<ExternalCommEntry> externalComms;
   final bool? defenderEnabled;
   final bool? firewallEnabled;
   final Future<String> Function()? onGenerateTopology;
@@ -50,6 +51,7 @@ class DiagnosticResultPage extends StatelessWidget {
     required this.items,
     this.portSummaries = const [],
     this.spfResults = const [],
+    this.externalComms = const [],
     this.defenderEnabled,
     this.firewallEnabled,
     this.onGenerateTopology,
@@ -249,6 +251,54 @@ class DiagnosticResultPage extends StatelessWidget {
     );
   }
 
+  Widget _externalCommSection() {
+    if (externalComms.isEmpty) return const SizedBox.shrink();
+    Color rowColor(String state) {
+      switch (state) {
+        case '危険':
+          return Colors.redAccent.withOpacity(0.2);
+        case '安全':
+          return Colors.green.withOpacity(0.2);
+        default:
+          return Colors.grey.withOpacity(0.2);
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('外部通信の暗号化状況',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 4),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('宛先')),
+              DataColumn(label: Text('プロトコル')),
+              DataColumn(label: Text('暗号化')),
+              DataColumn(label: Text('状態')),
+              DataColumn(label: Text('コメント')),
+            ],
+            rows: [
+              for (final e in externalComms)
+                DataRow(
+                  color: MaterialStateProperty.all(rowColor(e.state)),
+                  cells: [
+                    DataCell(Text(e.dest)),
+                    DataCell(Text(e.protocol)),
+                    DataCell(Text(e.encryption)),
+                    DataCell(Text(e.state)),
+                    DataCell(Text(e.comment)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _defenseSection() {
     if (defenderEnabled == null && firewallEnabled == null) {
       return const SizedBox.shrink();
@@ -398,6 +448,8 @@ class DiagnosticResultPage extends StatelessWidget {
             _portStatusSection(),
             const SizedBox(height: 16),
             _spfSection(),
+            const SizedBox(height: 16),
+            _externalCommSection(),
             const SizedBox(height: 16),
             _defenseSection(),
             const SizedBox(height: 16),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -46,4 +46,25 @@ void main() {
     expect(find.textContaining('3389'), findsOneWidget);
     expect(find.textContaining('危険'), findsOneWidget);
   });
+
+  testWidgets('External communication table is displayed', (tester) async {
+    final comms = [
+      const ExternalCommEntry('example.com', 'HTTP', '非暗号化', '危険', 'r')
+    ];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 5,
+          riskScore: 5,
+          items: const [],
+          externalComms: comms,
+        ),
+      ),
+    );
+
+    expect(find.text('外部通信の暗号化状況'), findsOneWidget);
+    expect(find.text('example.com'), findsOneWidget);
+    expect(find.text('HTTP'), findsOneWidget);
+    expect(find.text('非暗号化'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add `--json` output to `external_ip_report.py`
- wrap external comm report in Dart and display in results
- show external communication encryption table on diagnostic page
- test JSON output and widget table
- document new feature in README

## Testing
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c77ce8ba08323bd98457f30fe5467