### PR TITLE
Install helper scripts in desktop bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ Flutter ウィジェットテストを実行するには次のコマンドを利
 flutter test
 ```
 
+## リリースバンドルに含めるファイル
+
+デスクトップ版を配布する際は、以下の Python スクリプトを実行ファイルと同じ
+ディレクトリに配置してください。`flutter build windows` や `flutter build linux`
+で作成したバンドルにこれらを含めないと、アプリから外部スクリプトを呼び出せなく
+なります。
+
+- `discover_hosts.py`
+- `port_scan.py`
+- `lan_port_scan.py`
+- `network_speed.py`
+- `security_report.py`
+
 ## 貢献
 
 詳しい貢献方法は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -126,3 +126,14 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
   install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
     COMPONENT Runtime)
 endif()
+
+# Install required Python helper scripts into the release bundle so that the
+# executable can call them via the relative path.
+install(FILES
+  "${CMAKE_CURRENT_LIST_DIR}/../discover_hosts.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../port_scan.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../lan_port_scan.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../network_speed.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../security_report.py"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -106,3 +106,14 @@ install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
 install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
   CONFIGURATIONS Profile;Release
   COMPONENT Runtime)
+
+# Install required Python helper scripts next to the executable so that the
+# Flutter app can invoke them at runtime.
+install(FILES
+  "${CMAKE_CURRENT_LIST_DIR}/../discover_hosts.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../port_scan.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../lan_port_scan.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../network_speed.py"
+  "${CMAKE_CURRENT_LIST_DIR}/../security_report.py"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)


### PR DESCRIPTION
## Summary
- install Python helper scripts in Windows and Linux bundles
- document required scripts in README

## Testing
- `pytest -q test`
- `./flutter-sdk/bin/flutter build windows` *(fails: blocked download URL)*
- `./flutter-sdk/bin/flutter build linux` *(fails: blocked download URL)*

------
https://chatgpt.com/codex/tasks/task_e_686c96077bac8323b61ff31e62744b32