### PR TITLE
Bundle python helper scripts in release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,16 +274,18 @@ flutter test
 
 ## リリースバンドルに含めるファイル
 
-デスクトップ版を配布する際は、以下の Python スクリプトを実行ファイルと同じ
-ディレクトリに配置してください。`flutter build windows` や `flutter build linux`
-で作成したバンドルにこれらを含めないと、アプリから外部スクリプトを呼び出せなく
-なります。
+デスクトップ版を配布する際は、リポジトリ直下の Python スクリプトをすべて実行
+ファイルと同じディレクトリに配置してください。`flutter build windows` や
+`flutter build linux` で作成したバンドルにこれらを含めないと、アプリから外部ス
+クリプトを呼び出せなくなります。主なスクリプトは次の通りです。
 
 - `discover_hosts.py`
 - `port_scan.py`
 - `lan_port_scan.py`
 - `network_speed.py`
 - `security_report.py`
+- `generate_html_report.py`
+- `generate_topology.py`
 
 ## 貢献
 

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -129,11 +129,7 @@ endif()
 
 # Install required Python helper scripts into the release bundle so that the
 # executable can call them via the relative path.
-install(FILES
-  "${CMAKE_CURRENT_LIST_DIR}/../discover_hosts.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../port_scan.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../lan_port_scan.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../network_speed.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../security_report.py"
+file(GLOB PY_HELPERS "${CMAKE_CURRENT_LIST_DIR}/../*.py")
+install(FILES ${PY_HELPERS}
   DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -109,11 +109,7 @@ install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
 
 # Install required Python helper scripts next to the executable so that the
 # Flutter app can invoke them at runtime.
-install(FILES
-  "${CMAKE_CURRENT_LIST_DIR}/../discover_hosts.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../port_scan.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../lan_port_scan.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../network_speed.py"
-  "${CMAKE_CURRENT_LIST_DIR}/../security_report.py"
+file(GLOB PY_HELPERS "${CMAKE_CURRENT_LIST_DIR}/../*.py")
+install(FILES ${PY_HELPERS}
   DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)


### PR DESCRIPTION
## Summary
- install all Python helper scripts next to the executable for Windows and Linux builds
- note in README that release bundles must include these scripts

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c97a3594483238c680985b4cb5f20