### PR TITLE
Fix FormatException when Python output empty

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -90,7 +90,11 @@ Future<NetworkSpeed?> measureNetworkSpeed() async {
     if (result.exitCode != 0) {
       return null;
     }
-    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final output = result.stdout.toString();
+    if (output.trim().isEmpty) {
+      return null;
+    }
+    final data = jsonDecode(output) as Map<String, dynamic>;
     final down = (data['download'] as num).toDouble();
     final up = (data['upload'] as num).toDouble();
     final ping = (data['ping'] as num).toDouble();
@@ -113,7 +117,11 @@ Future<PortScanSummary> scanPorts(String host, [List<int>? ports]) async {
     if (result.exitCode != 0) {
       throw result.stderr.toString();
     }
-    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final output = result.stdout.toString();
+    if (output.trim().isEmpty) {
+      return PortScanSummary(host, []);
+    }
+    final data = jsonDecode(output) as Map<String, dynamic>;
     final portList = <PortStatus>[];
     if (data.containsKey('ports')) {
       for (final item in data['ports']) {
@@ -154,7 +162,11 @@ Future<List<LanPortDevice>> scanLanWithPorts({
     if (result.exitCode != 0) {
       throw result.stderr.toString();
     }
-    final data = jsonDecode(result.stdout.toString()) as List<dynamic>;
+    final output = result.stdout.toString();
+    if (output.trim().isEmpty) {
+      return [];
+    }
+    final data = jsonDecode(output) as List<dynamic>;
     final devices = <LanPortDevice>[];
     for (final item in data) {
       final portList = <PortStatus>[];
@@ -237,7 +249,19 @@ Future<SecurityReport> runSecurityReport({
       spfValid ? 'true' : 'false',
       geoip,
     ]);
-    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final output = result.stdout.toString();
+    if (output.trim().isEmpty) {
+      return SecurityReport(
+        ip,
+        0,
+        [const RiskItem('error', 'No output from security_report.py')],
+        [],
+        '',
+        openPorts: [],
+        geoip: '',
+      );
+    }
+    final data = jsonDecode(output) as Map<String, dynamic>;
     final risks = <RiskItem>[];
     if (data['risks'] is List) {
       for (final r in data['risks']) {

--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -27,7 +27,13 @@ Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}
       if (onError != null) onError(msg);
       return [];
     }
-    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    final output = result.stdout.toString();
+    if (output.trim().isEmpty) {
+      stderr.writeln('discover_hosts.py produced no output');
+      if (onError != null) onError('Empty output from discover_hosts.py');
+      return [];
+    }
+    final data = jsonDecode(output) as Map<String, dynamic>;
     final devices = <NetworkDevice>[];
     if (data.containsKey('hosts')) {
       for (final item in data['hosts']) {


### PR DESCRIPTION
## Summary
- avoid FormatException when python scripts emit empty strings
- handle empty output for LAN discovery
- handle empty output for port scan, LAN+port scan and security report
- handle empty output for network speed test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_686caab4564c8323aab53bbe883c7b17