### PR TITLE
Fix portSummaries on result page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -242,7 +242,7 @@ class _HomePageState extends State<HomePage> {
           securityScore: securityScore,
           riskScore: riskScore,
           items: items,
-          portSummaries: const [],
+          portSummaries: _scanResults,
         ),
       ),
     );

--- a/test/open_result_page_test.dart
+++ b/test/open_result_page_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/main.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
+
+void main() {
+  testWidgets('port summaries shown when result page opened', (tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    final state = tester.state(find.byType(HomePage)) as dynamic;
+    state.setState(() {
+      state._scanResults = [
+        const PortScanSummary('1.1.1.1', [
+          PortStatus(80, 'open', 'http'),
+        ])
+      ];
+    });
+
+    await tester.tap(find.text('診断結果ページ'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.textContaining('80'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- pass collected port scan summaries to `DiagnosticResultPage`
- add widget test showing summaries appear when result page is opened

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686cafbfdefc8323926f816f980a2b48