### PR TITLE
Handle double risk scores

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -45,7 +45,7 @@ class RiskItem {
 
 class SecurityReport {
   final String ip;
-  final int score;
+  final double score;
   final List<RiskItem> risks;
   final List<String> utmItems;
   final String path;
@@ -253,7 +253,7 @@ Future<SecurityReport> runSecurityReport({
     if (output.trim().isEmpty) {
       return SecurityReport(
         ip,
-        0,
+        0.0,
         [const RiskItem('error', 'No output from security_report.py')],
         [],
         '',
@@ -291,11 +291,12 @@ Future<SecurityReport> runSecurityReport({
       }
     }
     final country = data['geoip']?.toString() ?? '';
+    final score = data['score'] is num
+        ? (data['score'] as num).toDouble()
+        : double.tryParse(data['score'].toString()) ?? 0.0;
     return SecurityReport(
       data['ip']?.toString() ?? ip,
-      data['score'] is int
-          ? data['score'] as int
-          : int.tryParse(data['score'].toString()) ?? 0,
+      score,
       risks,
       utm,
       data['path']?.toString() ?? '',
@@ -305,7 +306,7 @@ Future<SecurityReport> runSecurityReport({
   } catch (e) {
     return SecurityReport(
       ip,
-      0,
+      0.0,
       [RiskItem('error', e.toString())],
       [],
       '',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -445,13 +445,13 @@ class _HomePageState extends State<HomePage> {
   }
 }
 
-Color _scoreColor(int score) {
+Color _scoreColor(double score) {
   if (score >= 8) return Colors.green;
   if (score >= 5) return Colors.orange;
   return Colors.redAccent;
 }
 
-String _riskState(int score) {
+String _riskState(double score) {
   if (score >= 8) return '安全';
   if (score >= 5) return '注意';
   return '危険';

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -48,19 +48,19 @@ class DiagnosticResultPage extends StatelessWidget {
     this.onGenerateTopology,
   });
 
-  Color _scoreColor(int score) {
+  Color _scoreColor(double score) {
     if (score >= 8) return Colors.green;
     if (score >= 5) return Colors.orange;
     return Colors.redAccent;
   }
 
-  String _scoreMessage(int score) {
+  String _scoreMessage(double score) {
     if (score >= 8) return '社内ネットワークは安全です';
     if (score >= 5) return '注意が必要です';
     return '危険な状態です';
   }
 
-  Widget _scoreSection(String label, int score) {
+  Widget _scoreSection(String label, double score) {
     final color = _scoreColor(score);
     IconData icon;
     if (score >= 8) {
@@ -273,9 +273,9 @@ class DiagnosticResultPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _scoreSection('セキュリティスコア', securityScore),
+            _scoreSection('セキュリティスコア', securityScore.toDouble()),
             const SizedBox(height: 16),
-            _scoreSection('リスクスコア', riskScore),
+            _scoreSection('リスクスコア', riskScore.toDouble()),
             const SizedBox(height: 16),
             _portStatusSection(),
             const SizedBox(height: 16),
@@ -337,13 +337,13 @@ class ResultPage extends StatelessWidget {
 
   const ResultPage({super.key, required this.reports, required this.onSave});
 
-  Color _scoreColor(int score) {
+  Color _scoreColor(double score) {
     if (score >= 8) return Colors.green;
     if (score >= 5) return Colors.orange;
     return Colors.redAccent;
   }
 
-  String _riskState(int score) {
+  String _riskState(double score) {
     if (score >= 8) return '安全';
     if (score >= 5) return '注意';
     return '危険';

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -8,9 +8,9 @@ import 'dart:io';
 void main() {
   testWidgets('ResultPage displays scores and items', (WidgetTester tester) async {
     const reports = [
-      SecurityReport('1.1.1.1', 9, [RiskItem('risk1', 'fix1')], [], '',
+      SecurityReport('1.1.1.1', 9.0, [RiskItem('risk1', 'fix1')], [], '',
           openPorts: [80], geoip: 'US'),
-      SecurityReport('2.2.2.2', 4, [RiskItem('risk2', 'fix2')], [], '',
+      SecurityReport('2.2.2.2', 4.0, [RiskItem('risk2', 'fix2')], [], '',
           openPorts: [22], geoip: 'JP'),
     ];
 
@@ -23,8 +23,8 @@ void main() {
     expect(find.text('Scores'), findsOneWidget);
     expect(find.text('1.1.1.1'), findsOneWidget);
     expect(find.text('2.2.2.2'), findsOneWidget);
-    expect(find.text('9'), findsOneWidget);
-    expect(find.text('4'), findsOneWidget);
+    expect(find.text('9.0'), findsOneWidget);
+    expect(find.text('4.0'), findsOneWidget);
     expect(find.text('risk1'), findsOneWidget);
     expect(find.text('risk2'), findsOneWidget);
     expect(find.text('レポート保存'), findsOneWidget);

--- a/test/score_chart_test.dart
+++ b/test/score_chart_test.dart
@@ -6,9 +6,9 @@ import 'package:nwc_densetsu/diagnostics.dart';
 void main() {
   testWidgets('ScoreChart renders', (WidgetTester tester) async {
     final reports = [
-      const SecurityReport('1.1.1.1', 9, <RiskItem>[], [], '',
+      const SecurityReport('1.1.1.1', 9.0, <RiskItem>[], [], '',
           openPorts: [80], geoip: 'US'),
-      const SecurityReport('2.2.2.2', 3, <RiskItem>[], [], '',
+      const SecurityReport('2.2.2.2', 3.0, <RiskItem>[], [], '',
           openPorts: [22], geoip: 'JP'),
     ];
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- allow `SecurityReport.score` to use `double`
- handle float risk scores when running security report
- adapt UI helpers to accept `double`
- update widget tests for new score type

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb052485c8323b8ef51f6f1f50d27