### PR TITLE
Fix domain sender script and extend tests

### DIFF
--- a/test/test_verify_domain_sender.py
+++ b/test/test_verify_domain_sender.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+import json
 
 import verify_domain_sender
 
@@ -24,6 +25,24 @@ class VerifyDomainSenderTest(unittest.TestCase):
         res = verify_domain_sender.check_domain('example.com')
         self.assertEqual(res['status'], 'danger')
         self.assertEqual(res['comment'], 'No SPF record found')
+
+    @patch('dns_records.get_spf_record', return_value='v=spf1 +mx -all')
+    @patch('dns_records.get_dkim_record', return_value='v=DKIM1')
+    @patch('dns_records.get_dmarc_record', return_value='v=DMARC1')
+    @patch('verify_domain_sender.lookup_spf', return_value='')
+    def test_cli_multiple_domains(self, *_mocks):
+        with patch('sys.argv', ['verify_domain_sender.py', '--domains', 'example.com', 'test.com']):
+            with patch('sys.stdout') as mock_out:
+                verify_domain_sender.main()
+                output = ''.join(call.args[0] for call in mock_out.write.call_args_list)
+
+        entries = [json.loads(line) for line in output.splitlines() if line.strip()]
+        self.assertEqual(len(entries), 2)
+        for ent in entries:
+            self.assertEqual(ent['status'], 'safe')
+            self.assertEqual(ent['spf'], 'v=spf1 +mx -all')
+            self.assertEqual(ent['dkim'], 'v=DKIM1')
+            self.assertEqual(ent['dmarc'], 'v=DMARC1')
 
 
 if __name__ == '__main__':

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -12,6 +12,17 @@ from dns_records import (
     get_dmarc_record,
 )
 
+
+def lookup_spf(domain: str) -> str:
+    """Fallback SPF lookup using nslookup."""
+    result = subprocess.run(
+        ["nslookup", "-type=txt", domain], capture_output=True, text=True
+    )
+    for line in result.stdout.splitlines():
+        if "v=spf1" in line:
+            return line.strip()
+    return ""
+
 def check_domain(domain: str, offline: str | None = None, zone_file: str | None = None) -> dict:
     record = ''
     comment = ''


### PR DESCRIPTION
## Summary
- fix verify_domain_sender by restoring lookup_spf helper
- add unit test for CLI domain list support

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686cb0faecac83239ac22313955a2a62