### PR TITLE
Fix domain handling in LAN scan

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -457,7 +457,8 @@ Future<SecurityReport> runSecurityReport({
   }
 }
 
-/// Performs diagnostics for [ip] and returns a [SecurityReport].
+/// Performs diagnostics for [ip] using the given [domain] for DNS based
+/// checks and returns a [SecurityReport].
 Future<SecurityReport> analyzeHost(
   String ip, {
   List<int>? ports,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -149,7 +149,7 @@ class _HomePageState extends State<HomePage> {
         });
         return value;
       });
-      final domain = d.name.isNotEmpty ? d.name : ip;
+      final domain = d.name;
       final spfFuture = diag.checkSpfRecord(domain).then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -12,6 +12,21 @@ from dns_records import (
     get_dmarc_record,
 )
 
+
+def lookup_spf(domain: str) -> str:
+    """Return the SPF TXT record for *domain* using nslookup."""
+    try:
+        result = subprocess.run(
+            ["nslookup", "-type=txt", domain], capture_output=True, text=True
+        )
+        for line in result.stdout.split("\n"):
+            if "v=spf1" in line.lower():
+                return line.strip()
+    except Exception:
+        # Ignore lookup failures and return empty string
+        pass
+    return ""
+
 def check_domain(domain: str, offline: str | None = None, zone_file: str | None = None) -> dict:
     record = ''
     comment = ''


### PR DESCRIPTION
## Summary
- pass device domain names to SPF/DKIM/DMARC checks
- clarify `analyzeHost` documentation
- restore missing `lookup_spf` helper for verify_domain_sender

## Testing
- `python -m unittest discover -s test -p 'test_*.py' -v`

------
https://chatgpt.com/codex/tasks/task_e_686cb0ffa5f083239d005d1ff2596e73