### PR TITLE
Add test for floating security score

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -8,6 +8,12 @@ import 'network_scan.dart' as net;
 
 typedef LanDevice = net.NetworkDevice;
 
+typedef ProcessRunner = Future<ProcessResult> Function(
+    String executable, List<String> arguments);
+
+Future<ProcessResult> _defaultRunner(String exe, List<String> args) =>
+    Process.run(exe, args);
+
 class PortStatus {
   final int port;
   final String state;
@@ -238,10 +244,11 @@ Future<SecurityReport> runSecurityReport({
   required bool sslValid,
   required bool spfValid,
   String geoip = 'JP',
+  ProcessRunner processRunner = _defaultRunner,
 }) async {
   const script = 'security_report.py';
   try {
-    final result = await Process.run('python', [
+    final result = await processRunner('python', [
       script,
       ip,
       openPorts.join(','),
@@ -291,11 +298,15 @@ Future<SecurityReport> runSecurityReport({
       }
     }
     final country = data['geoip']?.toString() ?? '';
+    int parsedScore() {
+      final value = data['score'];
+      if (value is num) return value.round();
+      final d = double.tryParse(value.toString());
+      return d?.round() ?? 0;
+    }
     return SecurityReport(
       data['ip']?.toString() ?? ip,
-      data['score'] is int
-          ? data['score'] as int
-          : int.tryParse(data['score'].toString()) ?? 0,
+      parsedScore(),
       risks,
       utm,
       data['path']?.toString() ?? '',

--- a/test/run_security_report_test.dart
+++ b/test/run_security_report_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
+
+void main() {
+  test('runSecurityReport parses floating score', () async {
+    Future<ProcessResult> fakeRunner(String exe, List<String> args) async {
+      final data = {
+        'ip': '1.2.3.4',
+        'score': 6.7,
+        'risks': [],
+        'utmItems': [],
+        'open_ports': [],
+        'geoip': 'JP',
+        'path': ''
+      };
+      final json = jsonEncode(data);
+      return ProcessResult(0, 0, json, '');
+    }
+
+    final report = await runSecurityReport(
+      ip: '1.2.3.4',
+      openPorts: const [],
+      sslValid: true,
+      spfValid: true,
+      processRunner: fakeRunner,
+    );
+
+    expect(report.score, 7);
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting a custom process runner into `runSecurityReport`
- round numeric scores when parsing security report output
- add a dart test verifying float score handling

## Testing
- `flutter test` *(fails: flutter not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb0703448832391fb2c12a9cd1693