### PR TITLE
Add offline TXT lookup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ nmap -V # または arp-scan --version
 オフライン環境では `dns_records.py` に用意した `--zone-file` オプションを利用し、
 SPF/DKIM/DMARC の TXT レコードをゾーンファイルから読み取れます。BIND 形式や
 `dig example.com TXT` を保存したテキストを指定してください。
+ゾーンファイルでは 1 行につき 1 レコードを記述し、TXT レコードのみを対象とします。
 
 ### ゾーンファイル形式
 
-`dns_records.py` が参照するファイルは以下のような簡易 BIND 形式です。1 行に 1
-レコードを記述し、TXT レコードのみを対象とします。
+`dns_records.py` が参照するファイルは以下のような簡易 BIND 形式です。各行は
+`<name> IN TXT "value"` の形式で、末尾のピリオドや引用符を含めて記述します。
 
 ```
 example.com.                     IN TXT "v=spf1 +mx -all"

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -311,46 +311,30 @@ Future<SpfResult> checkSpfRecord(String domain, {String? recordsFile}) async {
 /// containing `v=DKIM1` will result in `true` being returned.
 Future<bool> checkDkimRecord(
   String domain, {
-  String? filePath,
+  String? recordsFile,
   List<String> selectors = const ['default', 'google', 'selector1'],
 }) async {
-  try {
-    final lines = <String>[];
-    if (filePath != null) {
-      final text = await File(filePath).readAsString();
-      lines.addAll(text.split('\n'));
+  const script = 'dns_records.py';
+  for (final selector in selectors) {
+    final args = <String>[script, domain, '--selector', selector];
+    if (recordsFile != null) {
+      args.addAll(['--zone-file', recordsFile]);
     }
-
-    for (final selector in selectors) {
-      final query = '$selector._domainkey.$domain';
-
-      String output;
-      if (filePath != null) {
-        // Try to find a matching line in the provided file first.
-        for (final line in lines) {
-          if (line.contains(query) &&
-              line.toLowerCase().contains('v=dkim1')) {
-            return true;
-          }
-        }
-        // Fall back to searching the whole file for v=DKIM1.
-        output = lines.join('\n');
-      } else {
-        final result = await Process.run('nslookup', ['-type=txt', query]);
-        output = result.stdout.toString();
+    try {
+      final result = await Process.run('python', args);
+      if (result.exitCode != 0) {
+        continue;
       }
-
-      for (final line in output.split('\n')) {
-        if (line.toLowerCase().contains('v=dkim1')) {
-          return true;
-        }
+      final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+      final record = data['dkim']?.toString() ?? '';
+      if (record.toLowerCase().contains('v=dkim1')) {
+        return true;
       }
+    } catch (_) {
+      // ignore and try next selector
     }
-
-    return false;
-  } catch (_) {
-    return false;
   }
+  return false;
 }
 
 /// Checks DMARC TXT record either online or from a zone file using

--- a/test/dkim_dmarc_test.dart
+++ b/test/dkim_dmarc_test.dart
@@ -9,7 +9,7 @@ void main() {
         'google._domainkey.example.com. IN TXT "v=DKIM1; k=rsa"');
     final ok = await diag.checkDkimRecord(
       'example.com',
-      filePath: file.path,
+      recordsFile: file.path,
       selectors: ['default', 'google'],
     );
     expect(ok, isTrue);
@@ -19,7 +19,7 @@ void main() {
   test('checkDmarcRecord detects absence', () async {
     final file = File('${Directory.systemTemp.path}/dmarc.txt');
     await file.writeAsString('no record');
-    final ok = await diag.checkDmarcRecord('example.com', filePath: file.path);
+    final ok = await diag.checkDmarcRecord('example.com', recordsFile: file.path);
     expect(ok, isFalse);
     await file.delete();
   });

--- a/test/spf_record_test.dart
+++ b/test/spf_record_test.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/diagnostics.dart' as diag;
+
+void main() {
+  test('checkSpfRecord reads zone file', () async {
+    final file = File('${Directory.systemTemp.path}/spf.txt');
+    await file.writeAsString('example.com. IN TXT "v=spf1 +mx -all"');
+    final res = await diag.checkSpfRecord('example.com', recordsFile: file.path);
+    expect(res.record, 'v=spf1 +mx -all');
+    expect(res.status, 'safe');
+    await file.delete();
+  });
+}


### PR DESCRIPTION
## Summary
- handle DKIM lookups via `dns_records.py`
- expose `recordsFile` parameter across TXT record helpers
- clarify zone‑file format in README
- add offline SPF test
- fix verify_domain_sender lookup fallback

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb107cf288323aef0ce7c7cb19f6a