### PR TITLE
Remove unused getter

### DIFF
--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -8,9 +8,6 @@ class NetworkDevice {
   final String mac;
   final String vendor;
 
-  /// Convenience getter mirroring [vendor] for widget state bindings.
-  String get vendorWidgetStateProperty => vendor;
-
   const NetworkDevice(this.ip, this.mac, this.vendor);
 }
 


### PR DESCRIPTION
## Summary
- delete vendorWidgetStateProperty

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb133d29483239ce1c7cc4cacd127