### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,15 @@ python generate_topology.py scan_results.json -o topology.svg
 
 ## テスト
 
-Python スクリプトのユニットテストは `test` ディレクトリにあります。すべて実行する
-場合は以下のコマンドを使用します。
+Python スクリプトのユニットテストは `test` ディレクトリにあります。実行する前に
+`requirements.txt` に記載された依存ライブラリ (例: `graphviz`) をインストールして
+ください。以下のコマンド、または `scripts/setup_test_env.sh` を使って準備できます。
+
+```bash
+pip install -r requirements.txt
+```
+
+すべてのテストを実行する場合は次のコマンドを利用します。
 
 ```bash
 python -m unittest discover -s test

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Simple setup script to install test dependencies
+set -e
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that running tests requires packages from `requirements.txt`
- add a simple `setup_test_env.sh` helper to install dependencies

## Testing
- `python -m unittest discover -s test` *(fails: lookup_spf not defined)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb20240cc8323a78d4b42f67655c2