### PR TITLE
Add GeoIP analysis UI

### DIFF
--- a/external_ip_report.py
+++ b/external_ip_report.py
@@ -147,6 +147,9 @@ def main():
             state = "安全" if flag == "\u6697\u53f7\u5316" else "危険" if flag == "\u975e\u6697\u53f7\u5316" else "不明"
             comment = risk_comment(port) if flag == "\u975e\u6697\u53f7\u5316" else ""
             data.append({
+                "ip": ip,
+                "domain": domain,
+                "country": country,
                 "dest": dest,
                 "protocol": proto,
                 "encryption": flag,

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -58,6 +58,22 @@ class ExternalCommEntry {
   }
 }
 
+class GeoipEntry {
+  final String ip;
+  final String domain;
+  final String country;
+
+  const GeoipEntry(this.ip, this.domain, this.country);
+
+  factory GeoipEntry.fromJson(Map<String, dynamic> json) {
+    return GeoipEntry(
+      json['ip']?.toString() ?? '',
+      json['domain']?.toString() ?? '',
+      json['country']?.toString() ?? '',
+    );
+  }
+}
+
 
 class RiskItem {
   final String description;
@@ -252,6 +268,24 @@ Future<List<ExternalCommEntry>> runExternalCommReport() async {
     return [
       for (final item in data)
         ExternalCommEntry.fromJson(item as Map<String, dynamic>)
+    ];
+  } catch (_) {
+    return [];
+  }
+}
+
+/// Runs external_ip_report.py and returns GeoIP entries with country info.
+Future<List<GeoipEntry>> runGeoipReport() async {
+  const script = 'external_ip_report.py';
+  try {
+    final result = await Process.run('python', [script, '--json']);
+    if (result.exitCode != 0) {
+      return [];
+    }
+    final data = jsonDecode(result.stdout.toString()) as List<dynamic>;
+    return [
+      for (final item in data)
+        GeoipEntry.fromJson(item as Map<String, dynamic>)
     ];
   } catch (_) {
     return [];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/port_constants.dart';
 import 'package:nwc_densetsu/ssl_check_section.dart';
 import 'package:nwc_densetsu/device_list_page.dart';
+import 'package:nwc_densetsu/geoip_result_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -52,12 +53,9 @@ class _HomePageState extends State<HomePage> {
   static const int _taskCount = 5; // port, SSL, SPF, DKIM, DMARC
   double _overallProgress = 0.0;
 
-  void _openGeoipPage() {
-    final entries = [
-      GeoipEntry('93.184.216.34', 'example.com', 'US'),
-      GeoipEntry('203.0.113.1', 'mal.example', 'CN'),
-      GeoipEntry('198.51.100.2', '', 'RU'),
-    ];
+  Future<void> _openGeoipPage() async {
+    final entries = await diag.runGeoipReport();
+    if (!mounted) return;
     Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => GeoipResultPage(entries: entries)),
     );
@@ -404,6 +402,11 @@ class _HomePageState extends State<HomePage> {
             ElevatedButton(
               onPressed: _openResultPage,
               child: const Text('診断結果ページ'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _openGeoipPage,
+              child: const Text('GeoIP解析ページ'),
             ),
             const SizedBox(height: 8),
             ElevatedButton(

--- a/test/geoip_result_page_test.dart
+++ b/test/geoip_result_page_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/geoip_result_page.dart';
+
+void main() {
+  testWidgets('GeoipResultPage shows entries and chart', (tester) async {
+    final entries = [
+      GeoipEntry('1.1.1.1', 'example.com', 'US'),
+      GeoipEntry('2.2.2.2', 'mal.example', 'CN'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GeoipResultPage(entries: entries),
+      ),
+    );
+
+    expect(find.text('GeoIP解析：通信先の国別リスクチェック'), findsOneWidget);
+    expect(find.text('example.com'), findsOneWidget);
+    expect(find.text('mal.example'), findsOneWidget);
+  });
+}

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -28,7 +28,7 @@ def check_domain(domain: str, offline: str | None = None, zone_file: str | None 
 
     if not record:
         try:
-            record = dns_records.get_spf_record(domain, records_file=zone_file) or lookup_spf(domain)
+            record = dns_records.get_spf_record(domain, records_file=zone_file)
             if not record and not comment:
                 comment = 'No SPF record found'
         except Exception as e:  # pragma: no cover - subprocess error


### PR DESCRIPTION
## Summary
- show GeoIP information and connection stats
- parse country data from `external_ip_report.py`
- expose a `runGeoipReport` helper
- hook up a GeoIP page in the Flutter app
- fix SPF check fallback logic
- test GeoIP UI widget

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb1fdd8e88323a93645dc088c5afb