### PR TITLE
Show LAN devices in result page

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -518,20 +518,17 @@ class DiagnosticResultPage extends StatelessWidget {
             SslCheckSection(results: sslEntries),
             const SizedBox(height: 16),
           ],
+          _portStatusSection(),
+          const SizedBox(height: 16),
+          _lanDevicesSection(context),
+          const SizedBox(height: 16),
+          _spfSection(),
+          const SizedBox(height: 16),
+          _externalCommSection(),
+          const SizedBox(height: 16),
+          _defenseSection(),
+          const SizedBox(height: 16),
           Expanded(
-            child: ListView.builder(
-              itemCount: items.length,
-            _portStatusSection(),
-            const SizedBox(height: 16),
-            _lanDevicesSection(context),
-            const SizedBox(height: 16),
-            _spfSection(),
-            const SizedBox(height: 16),
-            _externalCommSection(),
-            const SizedBox(height: 16),
-            _defenseSection(),
-            const SizedBox(height: 16),
-            Expanded(
               child: ListView.builder(
                 itemCount: items.length,
                 itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary
- restore layout in `DiagnosticResultPage` so that LAN devices table is shown

## Testing
- `python -m unittest discover -s test` *(fails: Failed to check SPF record: name 'lookup_spf' is not defined)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb1b404b483238aaf5c201676bab3