### PR TITLE
Implement DKIM selector lookup helper

### DIFF
--- a/dns_records.py
+++ b/dns_records.py
@@ -43,12 +43,32 @@ def get_spf_record(domain: str, records_file: Optional[str] = None) -> str:
     return _query_txt(name)
 
 
-def get_dkim_record(domain: str, selector: str = "default", records_file: Optional[str] = None) -> str:
+def get_dkim_record(
+    domain: str, selector: str = "default", records_file: Optional[str] = None
+) -> str:
     """Return DKIM record for selector._domainkey.domain."""
     name = f"{selector}._domainkey.{domain}"
     if records_file:
         return _find_in_file(records_file, name)
     return _query_txt(name)
+
+
+def check_dkim_record(
+    domain: str,
+    selectors: list[str] | None = None,
+    records_file: Optional[str] = None,
+) -> bool:
+    """Return ``True`` if any selector's DKIM record contains ``v=DKIM1``."""
+
+    if selectors is None:
+        selectors = ["default", "google", "selector1"]
+
+    for sel in selectors:
+        record = get_dkim_record(domain, selector=sel, records_file=records_file)
+        if "v=dkim1" in record.lower():
+            return True
+
+    return False
 
 
 def get_dmarc_record(domain: str, records_file: Optional[str] = None) -> str:

--- a/test/test_dns_records.py
+++ b/test/test_dns_records.py
@@ -1,7 +1,12 @@
 import unittest
 import json
 import subprocess
-from dns_records import get_spf_record, get_dkim_record, get_dmarc_record
+from dns_records import (
+    get_spf_record,
+    get_dkim_record,
+    get_dmarc_record,
+    check_dkim_record,
+)
 
 class DnsRecordFileTest(unittest.TestCase):
     def setUp(self):
@@ -14,6 +19,21 @@ class DnsRecordFileTest(unittest.TestCase):
     def test_dkim_from_file(self):
         rec = get_dkim_record('example.com', selector='default', records_file=self.zone)
         self.assertEqual(rec, 'v=DKIM1; k=rsa; p=abcd')
+
+    def test_check_dkim_record_selectors(self):
+        ok = check_dkim_record(
+            'example.com',
+            selectors=['google', 'default'],
+            records_file=self.zone,
+        )
+        self.assertTrue(ok)
+
+        ng = check_dkim_record(
+            'example.com',
+            selectors=['google'],
+            records_file=self.zone,
+        )
+        self.assertFalse(ng)
 
     def test_dmarc_from_file(self):
         rec = get_dmarc_record('example.com', records_file=self.zone)

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -12,6 +12,12 @@ from dns_records import (
     get_dmarc_record,
 )
 
+
+def lookup_spf(domain: str) -> str:
+    """Fallback SPF lookup using ``nslookup`` via :func:`dns_records.get_spf_record`."""
+
+    return dns_records.get_spf_record(domain)
+
 def check_domain(domain: str, offline: str | None = None, zone_file: str | None = None) -> dict:
     record = ''
     comment = ''


### PR DESCRIPTION
## Summary
- add `check_dkim_record` helper in `dns_records.py`
- use small `lookup_spf` helper to avoid NameError
- test multiple DKIM selectors

## Testing
- `python -m unittest discover -s test`

------
https://chatgpt.com/codex/tasks/task_e_686cb104d4f883239f9bb4f0d12d3477