### PR TITLE
Add test for runSecurityReport float score

### DIFF
--- a/test/run_security_report_json_score_test.dart
+++ b/test/run_security_report_json_score_test.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/diagnostics.dart';
+
+void main() {
+  test('runSecurityReport converts float score from JSON', () async {
+    Future<ProcessResult> fakeRunner(String exe, List<String> args) async {
+      final data = {
+        'ip': '8.8.8.8',
+        'score': 3.6,
+        'risks': [],
+        'utmItems': [],
+        'open_ports': [],
+        'geoip': 'JP',
+        'path': ''
+      };
+      return ProcessResult(0, 0, jsonEncode(data), '');
+    }
+
+    final report = await runSecurityReport(
+      ip: '8.8.8.8',
+      openPorts: const [],
+      sslValid: true,
+      spfValid: true,
+      processRunner: fakeRunner,
+    );
+
+    expect(report.score, 4);
+  });
+}


### PR DESCRIPTION
## Summary
- test that `runSecurityReport` correctly rounds float score from JSON output

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb62649d483238cb7ea8c763732d3