### PR TITLE
Handle float score values in diagnostics

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -298,11 +298,11 @@ Future<SecurityReport> runSecurityReport({
       }
     }
     final country = data['geoip']?.toString() ?? '';
-    int parsedScore() {
+    double parsedScore() {
       final value = data['score'];
-      if (value is num) return value.round();
+      if (value is num) return value.toDouble();
       final d = double.tryParse(value.toString());
-      return d?.round() ?? 0;
+      return d ?? 0.0;
     }
     return SecurityReport(
       data['ip']?.toString() ?? ip,

--- a/test/run_security_report_test.dart
+++ b/test/run_security_report_test.dart
@@ -28,6 +28,6 @@ void main() {
       processRunner: fakeRunner,
     );
 
-    expect(report.score, 7);
+    expect(report.score, 6.7);
   });
 }


### PR DESCRIPTION
## Summary
- allow `runSecurityReport` to return floating scores
- update test expectations for float score

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb6240c4083239b0cf6d38249a787