### PR TITLE
Document Python 3.10+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 本ツールは内部で Python スクリプトを呼び出し、LAN 内デバイスの探索には
 `arp-scan` または `nmap` を利用します。`arp-scan` が無い環境では `nmap`
 のみで動作するため、Windows では追加のインストールは必須ではありません。
-Python (3 系) といずれかのコマンドがインストールされていることを確認して
-ください。
+Python **3.10 以上** といずれかのコマンドがインストールされていることを確認して
+ください。Python 3.10 未満では `list[str] | None` などの最新の型ヒント構文が
+解釈できず、付属スクリプトが実行できません。
 ネットワーク速度計測には `speedtest-cli` を使用します。
 
 また、`nmap` や `arp-scan` の実行ファイルがシステムの `PATH` に含まれている必要
@@ -50,13 +51,15 @@ pip install speedtest-cli          # speedtest-cli
 
 ## Python ライブラリのインストール / Dependency Setup
 
-付属の Python スクリプトには `geoip2`, `psutil`, `pdfkit`, `weasyprint` などの
-モジュールが必要です。リポジトリのルートで次のコマンドを実行し、必要なライブラリ
-をまとめてインストールしてください:
+付属の Python スクリプトは Python 3.10 以降を前提としています。`geoip2`,
+`psutil`, `pdfkit`, `weasyprint` などのモジュールが必要なため、リポジトリの
+ルートで次のコマンドを実行し、必要なライブラリをまとめてインストールしてください:
 
 ```bash
 pip install -r requirements.txt
 ```
+Python のバージョン要件を満たしているか確認するための `check_python_version.py`
+スクリプトも用意しています。
 
 ## できること
 - **LANスキャン** ボタンを押すと `arp-scan` または `nmap` を使って LAN 内のデバイスを検出し、見つかった各 IP へ自動で診断を実行します。

--- a/check_python_version.py
+++ b/check_python_version.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Ensure the running interpreter is Python 3.10 or newer."""
+import sys
+
+REQUIRED = (3, 10)
+if sys.version_info < REQUIRED:
+    sys.stderr.write(
+        f"Python {REQUIRED[0]}.{REQUIRED[1]} or higher is required. "
+        f"Current version: {sys.version.split()[0]}\n"
+    )
+    sys.exit(1)
+
+print("Python version is sufficient.")


### PR DESCRIPTION
## Summary
- clarify that Python 3.10 or newer is required because the scripts use modern typing syntax
- note the requirement in dependency instructions
- add a small `check_python_version.py` helper to verify the interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbc8acb0483239477e28ab47c076e