### PR TITLE
Allow overriding Python executable

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'utils/python_utils.dart';
+
 import 'ssl_result.dart';
 export 'ssl_result.dart';
 import 'network_scan.dart' as net;
@@ -92,7 +94,7 @@ Future<String> runPing([String host = 'google.com']) async {
 Future<NetworkSpeed?> measureNetworkSpeed() async {
   const script = 'network_speed.py';
   try {
-    final result = await Process.run('python', [script]);
+    final result = await Process.run(pythonExecutable, [script]);
     if (result.exitCode != 0) {
       return null;
     }
@@ -119,7 +121,7 @@ Future<PortScanSummary> scanPorts(String host, [List<int>? ports]) async {
     if (ports != null && ports.isNotEmpty) {
       args.add(ports.join(','));
     }
-    final result = await Process.run('python', args);
+    final result = await Process.run(pythonExecutable, args);
     if (result.exitCode != 0) {
       throw result.stderr.toString();
     }
@@ -164,7 +166,7 @@ Future<List<LanPortDevice>> scanLanWithPorts({
     args.addAll(['--ports', ports.join(',')]);
   }
   try {
-    final result = await Process.run('python', [script, ...args]);
+    final result = await Process.run(pythonExecutable, [script, ...args]);
     if (result.exitCode != 0) {
       throw result.stderr.toString();
     }
@@ -248,7 +250,7 @@ Future<SecurityReport> runSecurityReport({
 }) async {
   const script = 'security_report.py';
   try {
-    final result = await processRunner('python', [
+    final result = await processRunner(pythonExecutable, [
       script,
       ip,
       openPorts.join(','),

--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'utils/python_utils.dart';
+
 /// Represents a discovered network device.
 class NetworkDevice {
   final String ip;
@@ -15,7 +17,7 @@ class NetworkDevice {
 Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}) async {
   const script = 'discover_hosts.py';
   try {
-    final result = await Process.run('python', [script]);
+    final result = await Process.run(pythonExecutable, [script]);
     if (result.exitCode != 0) {
       final msg = result.stderr.toString().trim();
       stderr.writeln(msg.isEmpty

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -4,6 +4,7 @@ import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
+import 'package:nwc_densetsu/utils/python_utils.dart';
 
 const Map<int, String> _dangerPortNotes = {
   3389: 'リモートデスクトップ接続が可能なため、攻撃の対象になりやすい',
@@ -198,7 +199,7 @@ class DiagnosticResultPage extends StatelessWidget {
   Future<void> _saveReport(BuildContext context) async {
     try {
       final result = await Process.run(
-        'python',
+        pythonExecutable,
         ['generate_html_report.py', 'sample_devices.json', '--pdf'],
       );
       final out = result.stdout.toString();

--- a/lib/utils/python_utils.dart
+++ b/lib/utils/python_utils.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+/// Returns the Python executable path.
+///
+/// The environment variable `PYTHON_EXECUTABLE` takes precedence. If not set,
+/// the function checks whether `python` can be executed and falls back to
+/// `python3` when unavailable.
+String getPythonExecutable() {
+  final override = Platform.environment['PYTHON_EXECUTABLE'];
+  if (override != null && override.isNotEmpty) {
+    return override;
+  }
+  try {
+    final result = Process.runSync('python', ['--version']);
+    if (result.exitCode == 0) return 'python';
+  } catch (_) {
+    // ignore errors and try python3
+  }
+  return 'python3';
+}
+
+/// Cached Python executable used by the application.
+final String pythonExecutable = getPythonExecutable();

--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'python_utils.dart';
+
 import 'package:path/path.dart' as p;
 
 import '../diagnostics.dart' show SecurityReport;
@@ -24,7 +26,7 @@ Future<void> savePdfReport(List<SecurityReport> reports) async {
     await File(jsonPath).writeAsString(jsonEncode(jsonList));
 
     final htmlPath = p.join(tempDir.path, 'report.html');
-    final result = await Process.run('python', [
+    final result = await Process.run(pythonExecutable, [
       'generate_html_report.py',
       jsonPath,
       '-o',
@@ -60,7 +62,7 @@ Future<void> savePdfReport(List<SecurityReport> reports) async {
 Future<String> generateTopologyDiagram() async {
   final tempDir = await Directory.systemTemp.createTemp('nwcd_topo');
   final outputPath = p.join(tempDir.path, 'topology.svg');
-  final result = await Process.run('python', [
+  final result = await Process.run(pythonExecutable, [
     'generate_topology.py',
     'sample_devices.json',
     '-o',


### PR DESCRIPTION
## Summary
- make python path configurable via `PYTHON_EXECUTABLE`
- use the detected python path across scanning and reporting utilities

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686cbc8ac1c08323845384ccabec50f3