### PR TITLE
Fix runSecurityReport score reference

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -306,6 +306,7 @@ Future<SecurityReport> runSecurityReport({
       final d = double.tryParse(value.toString());
       return d ?? 0.0;
     }
+    final double score = parsedScore();
     return SecurityReport(
       data['ip']?.toString() ?? ip,
       score,


### PR DESCRIPTION
## Summary
- ensure `score` variable is defined when building `SecurityReport`

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3b7fdc88323a18b5095047d7cb7