### PR TITLE
Add Graphviz skip in topology tests

### DIFF
--- a/test/test_generate_topology.py
+++ b/test/test_generate_topology.py
@@ -3,6 +3,9 @@ from unittest.mock import patch
 from pathlib import Path
 import tempfile
 
+import pytest
+pytest.importorskip("graphviz")
+
 import generate_topology
 
 

--- a/test/test_report_utils.py
+++ b/test/test_report_utils.py
@@ -3,6 +3,9 @@ import json
 from pathlib import Path
 import tempfile
 
+import pytest
+pytest.importorskip("graphviz")
+
 from report_utils import generate_topology_diagram, generateTopologyDiagram
 
 


### PR DESCRIPTION
## Summary
- skip topology tests if graphviz isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d12388f308323a34f1d94ee401cf0