### PR TITLE
Fix unused import

### DIFF
--- a/generate_html_report.py
+++ b/generate_html_report.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import html
 from pathlib import Path
-from typing import Any, Dict, List, Iterable
+from typing import Any, Dict, List
 
 from risk_score import calc_risk_score
 from report_utils import calc_utm_items


### PR DESCRIPTION
## Summary
- remove `Iterable` from `typing` imports in generate_html_report

## Testing
- `ruff check generate_html_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d122ea42883238980c25d3af3035e