### PR TITLE
Implement vendor lookup caching

### DIFF
--- a/discover_hosts.py
+++ b/discover_hosts.py
@@ -9,6 +9,9 @@ import os
 from pathlib import Path
 from urllib.request import urlopen
 
+# Cache for MAC prefix to vendor lookups
+_VENDOR_CACHE: dict[str, str] = {}
+
 def _get_subnet():
     if os.name == 'nt':
         try:
@@ -95,6 +98,10 @@ def _run_nmap_scan(subnet):
 
 def _lookup_vendor(mac):
     prefix = mac.upper().replace(':', '')[:6]
+
+    if prefix in _VENDOR_CACHE:
+        return _VENDOR_CACHE[prefix]
+
     db_path = Path('oui.txt')
     if db_path.exists():
         try:
@@ -104,13 +111,19 @@ def _lookup_vendor(mac):
                     if not line:
                         continue
                     if line.upper().startswith(prefix):
-                        return line[6:].strip()
+                        vendor = line[6:].strip()
+                        _VENDOR_CACHE[prefix] = vendor
+                        return vendor
         except Exception:
             pass
+
     try:
         with urlopen(f'https://api.macvendors.com/{mac}') as resp:
-            return resp.read().decode('utf-8')
+            vendor = resp.read().decode('utf-8')
+            _VENDOR_CACHE[prefix] = vendor
+            return vendor
     except Exception:
+        _VENDOR_CACHE[prefix] = ''
         return ''
 
 def main():

--- a/test/test_discover_hosts.py
+++ b/test/test_discover_hosts.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import discover_hosts
+
+class LookupVendorCacheTest(unittest.TestCase):
+    def setUp(self):
+        discover_hosts._VENDOR_CACHE.clear()
+
+    @patch('pathlib.Path.exists', return_value=False)
+    @patch('discover_hosts.urlopen')
+    def test_lookup_vendor_caches_result(self, mock_urlopen, mock_exists):
+        resp = MagicMock()
+        resp.read.return_value = b'MyVendor'
+        mock_urlopen.return_value.__enter__.return_value = resp
+
+        vendor1 = discover_hosts._lookup_vendor('aa:bb:cc:dd:ee:ff')
+        vendor2 = discover_hosts._lookup_vendor('AA:BB:CC:11:22:33')
+
+        self.assertEqual(vendor1, 'MyVendor')
+        self.assertEqual(vendor2, 'MyVendor')
+        mock_urlopen.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache MAC prefix to vendor lookups in `discover_hosts`
- avoid repeated API calls by using the cache
- add tests verifying caching functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686deffa38788323921a509067796354