### PR TITLE
Enable topology generation via Python script

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -31,7 +31,7 @@ class DiagnosticResultPage extends StatelessWidget {
   final double securityScore;
   final List<PortScanSummary> portSummaries;
   final List<DiagnosticItem> items;
-  final Future<String> Function()? onGenerateTopology;
+  final Future<String> Function(List<LanDeviceRisk>)? onGenerateTopology;
   final List<SslCheck> sslChecks;
   final List<SpfCheck> spfChecks;
   final List<DomainAuthCheck> domainAuths;
@@ -404,7 +404,7 @@ class DiagnosticResultPage extends StatelessWidget {
   Future<void> _showTopology(BuildContext context) async {
     try {
       final generator = onGenerateTopology;
-      final path = await (generator ?? report_utils.generateTopologyDiagram)();
+      final path = await (generator ?? report_utils.generateTopologyDiagram)(lanDevices);
       if (!context.mounted) return;
 
       final nodes = await _parseSvgNodes(path);

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -4,6 +4,7 @@ import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:io';
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 
 void main() {
   testWidgets('ResultPage displays scores and items', (WidgetTester tester) async {
@@ -63,8 +64,16 @@ void main() {
   });
 
   testWidgets('Topology button shows image dialog', (tester) async {
-    final imgFile = File('${Directory.systemTemp.path}/dummy.png');
-    await imgFile.writeAsBytes(List.filled(10, 0));
+    const devices = [
+      LanDeviceRisk(
+        ip: '192.168.1.2',
+        mac: '00:11',
+        vendor: 'Acme',
+        name: 'dev',
+        status: 'ok',
+        comment: '',
+      )
+    ];
 
     await tester.pumpWidget(
       MaterialApp(
@@ -72,7 +81,8 @@ void main() {
           securityScore: 4,
           items: const [],
           portSummaries: const [],
-          onGenerateTopology: () async => imgFile.path,
+          lanDevices: devices,
+          onGenerateTopology: report_utils.generateTopologyDiagram,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- generate a topology diagram using Python
- pass LAN device list to topology generator
- update topology dialog test to create real diagram

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfc9afd788323b24ecbd62a3616fd