### PR TITLE
Refine SSL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ JSON を読み込み、10.0 を満点とするセキュリティスコアを計�
 
 ```json
 [
-  {"device": "192.168.1.10", "danger_ports": 1, "geoip": "RU", "ssl": false, "open_port_count": 3},
-  {"device": "192.168.1.20", "danger_ports": 0, "geoip": "US", "ssl": true, "open_port_count": 2}
+  {"device": "192.168.1.10", "danger_ports": 1, "geoip": "RU", "ssl": "invalid", "open_port_count": 3},
+  {"device": "192.168.1.20", "danger_ports": 0, "geoip": "US", "ssl": "valid", "open_port_count": 2}
 ]
 ```
 
@@ -169,7 +169,7 @@ from security_score import calc_security_score
 result = calc_security_score({
     "danger_ports": 1,
     "geoip": "RU",
-    "ssl": False,
+    "ssl": "invalid",
     "open_port_count": 3,
 })
 print(result["score"], result["high_risk"])

--- a/generate_csv_report.py
+++ b/generate_csv_report.py
@@ -20,7 +20,7 @@ def generate_report(devices: List[Dict]) -> List[List[str]]:
             "danger_ports": danger,
             "geoip": countries[0] if countries else "",
             "open_port_count": len(ports),
-            "ssl": dev.get("ssl", True),
+            "ssl": dev.get("ssl", "valid"),
             "dns_fail_rate": 0.0,
         }
         res = calc_security_score(data)

--- a/generate_html_report.py
+++ b/generate_html_report.py
@@ -95,7 +95,7 @@ def generate_html(data: Any) -> str:
             "danger_ports": sum(1 for p in ports if p in {"3389", "445", "23"}),
             "geoip": countries[0] if countries else "",
             "open_port_count": len(ports),
-            "ssl": dev.get("ssl", True),
+            "ssl": dev.get("ssl", "valid"),
         }
         res = calc_security_score(data)
         score = res["score"]

--- a/sample_devices.json
+++ b/sample_devices.json
@@ -3,21 +3,21 @@
     "device": "192.168.1.10",
     "danger_ports": 1,
     "geoip": "RU",
-    "ssl": false,
+    "ssl": "invalid",
     "open_port_count": 3
   },
   {
     "device": "192.168.1.20",
     "danger_ports": 0,
     "geoip": "US",
-    "ssl": true,
+    "ssl": "valid",
     "open_port_count": 2
   },
   {
     "device": "192.168.1.30",
     "danger_ports": 0,
     "geoip": "JP",
-    "ssl": true,
+    "ssl": "self-signed",
     "open_port_count": 0
   }
 ]

--- a/security_report.py
+++ b/security_report.py
@@ -9,21 +9,21 @@ from report_utils import calc_utm_items
 def parse_args(argv):
     if len(argv) < 6:
         print(
-            "Usage: security_report.py <ip> <open_ports_csv> <ssl_valid> <spf_valid> <geoip>",
+            "Usage: security_report.py <ip> <open_ports_csv> <ssl_status> <spf_valid> <geoip>",
             file=sys.stderr,
         )
         sys.exit(1)
     ip = argv[1]
     ports = [p for p in argv[2].split(',') if p]
-    ssl_valid = argv[3].lower() in {"1", "true", "yes"}
+    ssl_status = argv[3].lower()
     spf_valid = argv[4].lower() in {"1", "true", "yes"}
     geoip = argv[5]
-    return ip, ports, ssl_valid, spf_valid, geoip
+    return ip, ports, ssl_status, spf_valid, geoip
 
 
 
 
-def calc_score(open_ports, ssl_valid, spf_valid, geoip):
+def calc_score(open_ports, ssl_status, spf_valid, geoip):
     """Return score, risk descriptions and UTM items."""
 
     risks = []
@@ -34,10 +34,10 @@ def calc_score(open_ports, ssl_valid, spf_valid, geoip):
                 "counter": "Close unused ports or enable a firewall",
             }
         )
-    if not ssl_valid:
+    if ssl_status in {"invalid", "self-signed"}:
         risks.append(
             {
-                "risk": "SSL certificate invalid",
+                "risk": f"SSL certificate {ssl_status}",
                 "counter": "Install a valid SSL certificate",
             }
         )
@@ -60,7 +60,7 @@ def calc_score(open_ports, ssl_valid, spf_valid, geoip):
         "danger_ports": sum(1 for p in open_ports if p in {"3389", "445", "23"}),
         "open_port_count": len(open_ports),
         "geoip": geoip,
-        "ssl": ssl_valid,
+        "ssl": ssl_status,
         "dns_fail_rate": 0.0 if spf_valid else 1.0,
     }
 
@@ -71,8 +71,8 @@ def calc_score(open_ports, ssl_valid, spf_valid, geoip):
 
 
 def main(argv):
-    ip, ports, ssl_valid, spf_valid, geoip = parse_args(argv)
-    score, risks, utm_items = calc_score(ports, ssl_valid, spf_valid, geoip)
+    ip, ports, ssl_status, spf_valid, geoip = parse_args(argv)
+    score, risks, utm_items = calc_score(ports, ssl_status, spf_valid, geoip)
     result = {
         "ip": ip,
         "score": score,

--- a/security_score.py
+++ b/security_score.py
@@ -32,8 +32,9 @@ def calc_security_score(data: Dict[str, Any]) -> Dict[str, Any]:
     elif geo and geo not in SAFE_COUNTRIES:
         medium += 1
 
-    if data.get("ssl") is False:
-        medium += 1
+    ssl_status = str(data.get("ssl", "")).lower()
+    if ssl_status in {"invalid", "self-signed"}:
+        high += 1
 
     if data.get("upnp"):
         medium += 1

--- a/test/test_security_report.py
+++ b/test/test_security_report.py
@@ -3,21 +3,21 @@ from security_report import calc_score
 
 class CalcScoreTest(unittest.TestCase):
     def test_all_safe(self):
-        score, risks, utm = calc_score([], True, True, 'JP')
+        score, risks, utm = calc_score([], 'valid', True, 'JP')
         self.assertEqual(score, 10.0)
         self.assertEqual(risks, [])
         self.assertEqual(utm, [])
 
     def test_high_risk_port_and_invalids(self):
-        score, risks, utm = calc_score(['3389'], False, False, 'RU')
-        self.assertAlmostEqual(score, 7.4, places=1)
+        score, risks, utm = calc_score(['3389'], 'invalid', False, 'RU')
+        self.assertAlmostEqual(score, 7.0, places=1)
         self.assertEqual(len(risks), 4)
         self.assertTrue(all('risk' in r and 'counter' in r for r in risks))
         self.assertEqual(utm, ['firewall', 'web_filter'])
 
     def test_many_open_ports(self):
         ports = [str(i) for i in range(1, 11)]
-        score, risks, utm = calc_score(ports, True, True, 'JP')
+        score, risks, utm = calc_score(ports, 'valid', True, 'JP')
         self.assertAlmostEqual(score, 9.7, places=1)
         self.assertTrue(risks)
         self.assertTrue(all('counter' in r for r in risks))

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -16,12 +16,12 @@ class CalcSecurityTest(unittest.TestCase):
         self.assertAlmostEqual(res["score"], 9.3, places=1)
 
     def test_mixed_levels(self):
-        data = {"danger_ports": 1, "ssl": False, "open_port_count": 2}
+        data = {"danger_ports": 1, "ssl": "invalid", "open_port_count": 2}
         res = calc_security_score(data)
-        self.assertEqual(res["high_risk"], 1)
-        self.assertEqual(res["medium_risk"], 1)
+        self.assertEqual(res["high_risk"], 2)
+        self.assertEqual(res["medium_risk"], 0)
         self.assertEqual(res["low_risk"], 1)
-        expected = 10 - 0.7 - 0.3 - 0.2
+        expected = 10 - 1.4 - 0.2
         self.assertAlmostEqual(res["score"], expected, places=1)
 
 

--- a/test/test_security_score_v2.py
+++ b/test/test_security_score_v2.py
@@ -8,7 +8,7 @@ class CalcSecurityScoreV2Test(unittest.TestCase):
         data = {
             "danger_ports": 20,
             "geoip": "RU",
-            "ssl": False,
+            "ssl": "self-signed",
             "open_port_count": 20,
             "dns_fail_rate": 1.0,
             "intl_traffic_ratio": 0.9,


### PR DESCRIPTION
## Summary
- support new `ssl` status strings in security scoring
- update security report parsing for new status strings
- fix tools and sample data for SSL statuses
- document status values in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3209e73083239bde7359172de9f4