### PR TITLE
Switch danger_ports to list of ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ JSON を読み込み、10.0 を満点とするセキュリティスコアを計�
 
 ```json
 [
-  {"device": "192.168.1.10", "danger_ports": 1, "geoip": "RU", "ssl": false, "open_port_count": 3},
-  {"device": "192.168.1.20", "danger_ports": 0, "geoip": "US", "ssl": true, "open_port_count": 2}
+  {"device": "192.168.1.10", "danger_ports": ["3389"], "geoip": "RU", "ssl": false, "open_port_count": 3},
+  {"device": "192.168.1.20", "danger_ports": [], "geoip": "US", "ssl": true, "open_port_count": 2}
 ]
 ```
 
@@ -167,7 +167,7 @@ RDP ポート (3389) が開いている、またはロシアなど危険国と�
 from security_score import calc_security_score
 
 result = calc_security_score({
-    "danger_ports": 1,
+    "danger_ports": ["3389"],
     "geoip": "RU",
     "ssl": False,
     "open_port_count": 3,

--- a/generate_csv_report.py
+++ b/generate_csv_report.py
@@ -15,9 +15,9 @@ def generate_report(devices: List[Dict]) -> List[List[str]]:
         name = dev.get("device") or dev.get("ip") or "unknown"
         ports = [str(p) for p in dev.get("open_ports", [])]
         countries = [c.upper() for c in dev.get("countries", [])]
-        danger = sum(1 for p in ports if p in {"3389", "445", "23"})
+        danger_list = [p for p in ports if p in {"3389", "445", "23"}]
         data = {
-            "danger_ports": danger,
+            "danger_ports": danger_list,
             "geoip": countries[0] if countries else "",
             "open_port_count": len(ports),
             "ssl": dev.get("ssl", True),

--- a/generate_html_report.py
+++ b/generate_html_report.py
@@ -91,8 +91,9 @@ def generate_html(data: Any) -> str:
         ip = dev.get("ip") or dev.get("device") or ""
         ports = [str(p) for p in dev.get("open_ports", [])]
         countries = _collect_countries(dev)
+        danger_list = [p for p in ports if p in {"3389", "445", "23"}]
         data = {
-            "danger_ports": sum(1 for p in ports if p in {"3389", "445", "23"}),
+            "danger_ports": danger_list,
             "geoip": countries[0] if countries else "",
             "open_port_count": len(ports),
             "ssl": dev.get("ssl", True),

--- a/sample_devices.json
+++ b/sample_devices.json
@@ -1,21 +1,21 @@
 [
   {
     "device": "192.168.1.10",
-    "danger_ports": 1,
+    "danger_ports": ["3389"],
     "geoip": "RU",
     "ssl": false,
     "open_port_count": 3
   },
   {
     "device": "192.168.1.20",
-    "danger_ports": 0,
+    "danger_ports": [],
     "geoip": "US",
     "ssl": true,
     "open_port_count": 2
   },
   {
     "device": "192.168.1.30",
-    "danger_ports": 0,
+    "danger_ports": [],
     "geoip": "JP",
     "ssl": true,
     "open_port_count": 0

--- a/security_report.py
+++ b/security_report.py
@@ -56,8 +56,9 @@ def calc_score(open_ports, ssl_valid, spf_valid, geoip):
             }
         )
 
+    danger_list = [p for p in open_ports if p in {"3389", "445", "23"}]
     data = {
-        "danger_ports": sum(1 for p in open_ports if p in {"3389", "445", "23"}),
+        "danger_ports": danger_list,
         "open_port_count": len(open_ports),
         "geoip": geoip,
         "ssl": ssl_valid,

--- a/security_score.py
+++ b/security_score.py
@@ -23,8 +23,13 @@ def calc_security_score(data: Dict[str, Any]) -> Dict[str, Any]:
 
     high = medium = low = 0
 
-    # number of ports considered dangerous (e.g. 3389, 445, telnet)
-    high += int(data.get("danger_ports", 0))
+    # list of ports considered dangerous (e.g. 3389, 445, telnet)
+    dp = data.get("danger_ports", [])
+    try:
+        high += len(list(dp))
+    except TypeError:
+        # fallback for legacy integer values
+        high += int(dp)
 
     geo = str(data.get("geoip", "")).upper()
     if geo in DANGER_COUNTRIES:

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -11,12 +11,12 @@ class CalcSecurityTest(unittest.TestCase):
         self.assertEqual(res["low_risk"], 0)
 
     def test_single_high(self):
-        res = calc_security_score({"danger_ports": 1})
+        res = calc_security_score({"danger_ports": ["3389"]})
         self.assertEqual(res["high_risk"], 1)
         self.assertAlmostEqual(res["score"], 9.3, places=1)
 
     def test_mixed_levels(self):
-        data = {"danger_ports": 1, "ssl": False, "open_port_count": 2}
+        data = {"danger_ports": ["23"], "ssl": False, "open_port_count": 2}
         res = calc_security_score(data)
         self.assertEqual(res["high_risk"], 1)
         self.assertEqual(res["medium_risk"], 1)

--- a/test/test_security_score_v2.py
+++ b/test/test_security_score_v2.py
@@ -6,7 +6,7 @@ from report_utils import calc_utm_items
 class CalcSecurityScoreV2Test(unittest.TestCase):
     def test_score_capping_and_utm(self):
         data = {
-            "danger_ports": 20,
+            "danger_ports": ["3389"] * 20,
             "geoip": "RU",
             "ssl": False,
             "open_port_count": 20,


### PR DESCRIPTION
## Summary
- treat `danger_ports` as a list of port numbers
- update security report utilities and docs for the new format
- adjust tests for the list-based `danger_ports`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3203891c8323974411a5369fab09