### PR TITLE
Fix flake8 E302/E303/E305 warnings

### DIFF
--- a/discover_hosts.py
+++ b/discover_hosts.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from urllib.request import urlopen
 
+
 def _get_subnet():
     if os.name == 'nt':
         try:
@@ -53,6 +54,7 @@ def _get_subnet():
             pass
     return None
 
+
 def _run_arp_scan():
     try:
         proc = subprocess.run(['arp-scan', '--localnet'], capture_output=True, text=True)
@@ -71,6 +73,7 @@ def _run_arp_scan():
     except Exception:
         pass
     raise RuntimeError('arp-scan failed')
+
 
 def _run_nmap_scan(subnet):
     cmd = ['nmap', '-sn', subnet, '-oX', '-']
@@ -93,6 +96,7 @@ def _run_nmap_scan(subnet):
             results.append({'ip': ip, 'mac': mac, 'vendor': vendor})
     return results
 
+
 def _lookup_vendor(mac):
     prefix = mac.upper().replace(':', '')[:6]
     db_path = Path('oui.txt')
@@ -113,6 +117,7 @@ def _lookup_vendor(mac):
     except Exception:
         return ''
 
+
 def main():
     subnet = None
     if len(sys.argv) > 1:
@@ -126,6 +131,7 @@ def main():
         if not h.get('vendor'):
             h['vendor'] = _lookup_vendor(h.get('mac', ''))
     print(json.dumps({'hosts': hosts}, ensure_ascii=False))
+
 
 if __name__ == '__main__':
     main()

--- a/generate_html_report.py
+++ b/generate_html_report.py
@@ -30,8 +30,10 @@ th { background: #eee; }
 .score-mid { background: #fff3cd; }
 """
 
+
 def _escape(val: Any) -> str:
     return html.escape(str(val))
+
 
 def _collect_countries(dev: Dict[str, Any]) -> List[str]:
     countries = [c for c in dev.get("countries", []) if c]
@@ -41,6 +43,7 @@ def _collect_countries(dev: Dict[str, Any]) -> List[str]:
         if country:
             countries.append(country)
     return [str(c).upper() for c in countries]
+
 
 def generate_html(data: Any) -> str:
     """Generate HTML from device list or combined result dict."""
@@ -140,6 +143,7 @@ def generate_html_report(devices: List[Dict[str, Any]]) -> str:
     """Wrapper that maintains backwards compatibility."""
     return generate_html(devices)
 
+
 def convert_to_pdf(html_path: Path, pdf_path: Path) -> None:
     if pdfkit:
         pdfkit.from_file(str(html_path), str(pdf_path))
@@ -147,6 +151,7 @@ def convert_to_pdf(html_path: Path, pdf_path: Path) -> None:
         WeasyHTML(filename=str(html_path)).write_pdf(str(pdf_path))
     else:
         raise RuntimeError("pdfkit or weasyprint is required for PDF output")
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Create HTML report from scan results")
@@ -157,7 +162,6 @@ def main() -> None:
 
     with open(args.input, "r", encoding="utf-8") as f:
         data = json.load(f)
-
 
     html_data = generate_html(data)
     out_path = Path(args.output)
@@ -171,6 +175,7 @@ def main() -> None:
             print(f"PDF written to {pdf_path}")
         except Exception as e:
             print(f"PDF conversion failed: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/lan_security_check.py
+++ b/lan_security_check.py
@@ -23,6 +23,7 @@ def _default_subnet() -> str:
     """Return detected subnet or a reasonable default."""
     return _get_subnet() or "192.168.1.0/24"
 
+
 def parse_arp_table(output: str) -> Dict[str, List[str]]:
     table: Dict[str, List[str]] = {}
     for line in output.splitlines():
@@ -33,6 +34,7 @@ def parse_arp_table(output: str) -> Dict[str, List[str]]:
         mac = m.group(2).lower().replace("-", ":")
         table.setdefault(ip, []).append(mac)
     return table
+
 
 def check_arp_spoofing() -> Dict[str, Any]:
     try:
@@ -51,8 +53,10 @@ def check_arp_spoofing() -> Dict[str, Any]:
     except Exception as e:
         return {"status": "unknown", "details": str(e)}
 
+
 def parse_upnp_output(output: str) -> bool:
     return "UPnP" in output or "upnp" in output
+
 
 def check_upnp(subnet: str) -> Dict[str, Any]:
     cmds = [["upnpc", "-l"], ["nmap", "-p", "1900", "-sU", "--script", "upnp-info", "-oN", "-", subnet]]
@@ -73,6 +77,7 @@ def check_upnp(subnet: str) -> Dict[str, Any]:
             return {"status": "unknown", "details": str(e)}
     return {"status": "unknown", "details": "no scanner"}
 
+
 def parse_netbios_output(output: str) -> List[str]:
     hosts = []
     for line in output.splitlines():
@@ -81,6 +86,7 @@ def parse_netbios_output(output: str) -> List[str]:
             if m:
                 hosts.append(m.group(1))
     return hosts
+
 
 def check_netbios(subnet: str) -> Dict[str, Any]:
     cmd = ["nmap", "-p", "137,138,139,445", "--open", "-oG", "-", subnet]
@@ -99,8 +105,10 @@ def check_netbios(subnet: str) -> Dict[str, Any]:
     except Exception as e:
         return {"status": "unknown", "details": str(e)}
 
+
 def parse_dhcp_output(output: str) -> int:
     return len(re.findall(r"Server Identifier", output))
+
 
 def check_dhcp_multiple() -> Dict[str, Any]:
     cmd = ["nmap", "--script", "broadcast-dhcp-discover"]
@@ -119,8 +127,10 @@ def check_dhcp_multiple() -> Dict[str, Any]:
     except Exception as e:
         return {"status": "unknown", "details": str(e)}
 
+
 def parse_smb_protocol_output(output: str) -> bool:
     return "SMBv1" in output or "SMB1" in output
+
 
 def check_smb_protocol(subnet: str) -> Dict[str, Any]:
     cmd = ["nmap", "-p", "445", "--script", "smb-protocols", "-oN", "-", subnet]
@@ -137,6 +147,7 @@ def check_smb_protocol(subnet: str) -> Dict[str, Any]:
         return {"status": "ok"}
     except Exception as e:
         return {"status": "unknown", "details": str(e)}
+
 
 def check_external_comm(geoip_db: str = "GeoLite2-Country.mmdb") -> Dict[str, Any]:
     try:
@@ -168,6 +179,7 @@ def check_external_comm(geoip_db: str = "GeoLite2-Country.mmdb") -> Dict[str, An
         })
     return result
 
+
 def main() -> None:
     subnet = sys.argv[1] if len(sys.argv) > 1 else _default_subnet()
     results = {
@@ -184,6 +196,7 @@ def main() -> None:
             utm.update(res.get("utm", []))
     results["utm_recommendations"] = sorted(utm)
     print(json.dumps(results, ensure_ascii=False))
+
 
 if __name__ == "__main__":
     main()

--- a/security_report.py
+++ b/security_report.py
@@ -21,8 +21,6 @@ def parse_args(argv):
     return ip, ports, ssl_valid, spf_valid, geoip
 
 
-
-
 def calc_score(open_ports, ssl_valid, spf_valid, geoip):
     """Return score, risk descriptions and UTM items."""
 

--- a/security_score.py
+++ b/security_score.py
@@ -94,7 +94,6 @@ def calc_security_score(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-
 def main():
     """Read risk data from JSON and print scores for each entry."""
 
@@ -113,6 +112,7 @@ def main():
             f"{name}\tScore: {res['score']}"
             f"\t(H:{res['high_risk']} M:{res['medium_risk']} L:{res['low_risk']})"
         )
+
 
 if __name__ == "__main__":
     main()

--- a/test/test_external_ip_report.py
+++ b/test/test_external_ip_report.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import external_ip_report
 
+
 class ExternalIPReportTest(unittest.TestCase):
     def test_classify_port_encrypted(self):
         self.assertEqual(external_ip_report.classify_port(443), "\u6697\u53f7\u5316")
@@ -36,6 +37,7 @@ class ExternalIPReportTest(unittest.TestCase):
         reader = MagicMock()
         reader.country.side_effect = Exception()
         self.assertEqual(external_ip_report.geoip_country(reader, '1.1.1.1'), '')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_firewall_check.py
+++ b/test/test_firewall_check.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import firewall_check
 
+
 class FirewallCheckTest(unittest.TestCase):
     @patch('firewall_check.os.name', 'nt')
     @patch('firewall_check.subprocess.run')
@@ -42,6 +43,7 @@ class FirewallCheckTest(unittest.TestCase):
     def test_get_firewall_status_linux_inactive(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout='inactive\n')
         self.assertFalse(firewall_check.get_firewall_status())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_lan_port_scan.py
+++ b/test/test_lan_port_scan.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 import lan_port_scan
 
+
 class LanPortScanJsonTest(unittest.TestCase):
     @patch('lan_port_scan.run_scan')
     @patch('lan_port_scan._run_arp_scan')
@@ -24,6 +25,7 @@ class LanPortScanJsonTest(unittest.TestCase):
         res = lan_port_scan.scan_hosts('10.0.0.0/24', ['80'])
         self.assertEqual(res[0]['ip'], '10.0.0.5')
         self.assertEqual(res[0]['ports'], [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_network_speed.py
+++ b/test/test_network_speed.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import network_speed
 
+
 class NetworkSpeedTest(unittest.TestCase):
     @patch.object(network_speed, 'speedtest')
     def test_measure_speed(self, mock_speedtest):
@@ -38,6 +39,7 @@ class NetworkSpeedTest(unittest.TestCase):
         mock_speedtest.Speedtest.return_value = inst
         result = network_speed.measure_speed()
         self.assertIsNone(result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import port_scan
 
+
 class PortScanScriptTest(unittest.TestCase):
     def test_run_scan_uses_all_ports_when_empty(self):
         xml = "<nmaprun></nmaprun>"
@@ -20,6 +21,7 @@ class PortScanScriptTest(unittest.TestCase):
             m.assert_called_with([
                 'nmap', '-sV', '-O', '--script', 'vuln', '-p-', '-oX', '-', '1.1.1.1'
             ], capture_output=True, text=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_security_report.py
+++ b/test/test_security_report.py
@@ -1,6 +1,7 @@
 import unittest
 from security_report import calc_score
 
+
 class CalcScoreTest(unittest.TestCase):
     def test_all_safe(self):
         score, risks, utm = calc_score([], True, True, 'JP')
@@ -22,6 +23,7 @@ class CalcScoreTest(unittest.TestCase):
         self.assertTrue(risks)
         self.assertTrue(all('counter' in r for r in risks))
         self.assertEqual(utm, ['firewall'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- clean up blank line spacing in Python modules and tests
- ensure proper separation before/after functions
- remove extraneous blank lines

## Testing
- `flake8 | grep -E 'E30[235]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e32027118832384b1f3b608d13694