### PR TITLE
Ensure tests skip if graphviz unavailable

### DIFF
--- a/test/html_report_test.py
+++ b/test/html_report_test.py
@@ -1,4 +1,8 @@
 import unittest
+import pytest
+
+pytest.importorskip("graphviz")
+
 from generate_html_report import generate_html_report
 
 

--- a/test/test_security_report.py
+++ b/test/test_security_report.py
@@ -1,4 +1,8 @@
 import unittest
+import pytest
+
+pytest.importorskip("graphviz")
+
 from security_report import calc_score
 
 class CalcScoreTest(unittest.TestCase):

--- a/test/test_security_score_v2.py
+++ b/test/test_security_score_v2.py
@@ -1,4 +1,8 @@
 import unittest
+import pytest
+
+pytest.importorskip("graphviz")
+
 from security_score import calc_security_score
 from report_utils import calc_utm_items
 


### PR DESCRIPTION
## Summary
- guard network report tests with `pytest.importorskip("graphviz")`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3201a1688323b80a6a94392fca45