### PR TITLE
Use constants for score weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,15 @@ RDP ポート (3389) が開いている、またはロシアなど危険国と�
 
 ## 0.0〜10.0 スコアリングシステム
 
-スコアは high_risk, medium_risk, low_risk の件数を用いて 
-`10 - high*0.7 - medium*0.3 - low*0.2` で計算されます。
+スコアは high_risk, medium_risk, low_risk の件数を用いて
+`10 - high*HIGH_WEIGHT - medium*MEDIUM_WEIGHT - low*LOW_WEIGHT` で計算されます。
+各定数のデフォルト値は `security_score.py` で次のように定義されています。
+
+```python
+HIGH_WEIGHT = 0.7
+MEDIUM_WEIGHT = 0.3
+LOW_WEIGHT = 0.2
+```
 数値が小さいほどリスクが高く、0 から 10 の範囲に丸められます。
 
 例として Python から直接呼び出す場合は次の通りです。

--- a/security_score.py
+++ b/security_score.py
@@ -9,6 +9,11 @@ from typing import Any, Dict
 
 from common_constants import DANGER_COUNTRIES, SAFE_COUNTRIES
 
+# Weighting factors for each risk level used in the final score calculation
+HIGH_WEIGHT = 0.7
+MEDIUM_WEIGHT = 0.3
+LOW_WEIGHT = 0.2
+
 __all__ = ["calc_security_score"]
 
 
@@ -83,7 +88,7 @@ def calc_security_score(data: Dict[str, Any]) -> Dict[str, Any]:
     if data.get("ip_conflict"):
         high += 1
 
-    score = 10.0 - high * 0.7 - medium * 0.3 - low * 0.2
+    score = 10.0 - high * HIGH_WEIGHT - medium * MEDIUM_WEIGHT - low * LOW_WEIGHT
     score = max(0.0, min(10.0, score))
 
     return {

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -1,5 +1,10 @@
 import unittest
-from security_score import calc_security_score
+from security_score import (
+    calc_security_score,
+    HIGH_WEIGHT,
+    MEDIUM_WEIGHT,
+    LOW_WEIGHT,
+)
 
 
 class CalcSecurityTest(unittest.TestCase):
@@ -21,7 +26,7 @@ class CalcSecurityTest(unittest.TestCase):
         self.assertEqual(res["high_risk"], 1)
         self.assertEqual(res["medium_risk"], 1)
         self.assertEqual(res["low_risk"], 1)
-        expected = 10 - 0.7 - 0.3 - 0.2
+        expected = 10 - HIGH_WEIGHT - MEDIUM_WEIGHT - LOW_WEIGHT
         self.assertAlmostEqual(res["score"], expected, places=1)
 
 


### PR DESCRIPTION
## Summary
- centralize risk weighting factors in `security_score.py`
- reference these constants in score calculation and tests
- document weighting constants in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e320120348323a980ca84250daa3d