### PR TITLE
Invoke generate_topology script from Flutter utils

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -403,8 +403,9 @@ class DiagnosticResultPage extends StatelessWidget {
 
   Future<void> _showTopology(BuildContext context) async {
     try {
-      final generator = onGenerateTopology;
-      final path = await (generator ?? report_utils.generateTopologyDiagram)();
+      final generator =
+          onGenerateTopology ?? () => report_utils.generateTopologyDiagram(lanDevices);
+      final path = await generator();
       if (!context.mounted) return;
 
       final nodes = await _parseSvgNodes(path);

--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -5,6 +5,8 @@ import 'package:path/path.dart' as p;
 
 import '../diagnostics.dart' show SecurityReport;
 import 'file_utils.dart';
+import '../extended_results.dart' show LanDeviceRisk;
+import 'python_utils.dart';
 
 /// Generates a PDF report from [reports] using the bundled Python script
 /// and saves it to a location chosen by the user.
@@ -52,7 +54,38 @@ Future<void> savePdfReport(List<SecurityReport> reports) async {
     }
   }
 }
-Future<String> generateTopologyDiagram() async {
-  // ここに本当はネットワーク構成からSVGを生成する処理が入る
-  return '<svg><!-- dummy topology diagram --></svg>';
+/// Generates a network topology diagram from [devices].
+///
+/// The function creates a temporary JSON file compatible with
+/// `generate_topology.py` and invokes the script. The returned path points
+/// to the produced SVG file.
+Future<String> generateTopologyDiagram([List<LanDeviceRisk> devices = const []])
+    async {
+  final tmpDir = await Directory.systemTemp.createTemp('nwcd_topology');
+  final jsonPath = p.join(tmpDir.path, 'scan.json');
+  final outputPath = p.join(tmpDir.path, 'topology.svg');
+
+  final data = {
+    'hosts': [
+      for (final d in devices)
+        {
+          'ip': d.ip,
+          if (d.vendor.isNotEmpty) 'vendor': d.vendor,
+        }
+    ]
+  };
+  await File(jsonPath).writeAsString(jsonEncode(data));
+
+  final result = await Process.run(pythonExecutable, [
+    'generate_topology.py',
+    jsonPath,
+    '-o',
+    outputPath,
+  ]);
+
+  if (result.exitCode != 0) {
+    throw Exception(result.stderr.toString());
+  }
+
+  return outputPath;
 }

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:nwc_densetsu/extended_results.dart';
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'dart:io';
 
 void main() {
@@ -63,8 +65,15 @@ void main() {
   });
 
   testWidgets('Topology button shows image dialog', (tester) async {
-    final imgFile = File('${Directory.systemTemp.path}/dummy.png');
-    await imgFile.writeAsBytes(List.filled(10, 0));
+    final devices = const [
+      LanDeviceRisk(
+          ip: '192.168.1.2',
+          mac: '00:11',
+          vendor: 'Test',
+          name: 'd',
+          status: 'ok',
+          comment: '')
+    ];
 
     await tester.pumpWidget(
       MaterialApp(
@@ -72,7 +81,10 @@ void main() {
           securityScore: 4,
           items: const [],
           portSummaries: const [],
-          onGenerateTopology: () async => imgFile.path,
+          lanDevices: devices,
+          onGenerateTopology: () async {
+            return report_utils.generateTopologyDiagram(devices);
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- run `generate_topology.py` from `generateTopologyDiagram`
- pass LAN device list when showing topology
- update result page test to create a real SVG

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4921c2b483238e4379d472db60e8