### PR TITLE
Fix network scan import path

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -6,7 +6,7 @@ import 'ssl_result.dart';
 export 'ssl_result.dart';
 import 'spf_result.dart';
 export 'spf_result.dart';
-import 'network_scan.dart' as net;
+import 'package:nwc_densetsu/network_scan.dart' as net;
 
 typedef LanDevice = net.NetworkDevice;
 


### PR DESCRIPTION
## Summary
- use the package path when importing `network_scan.dart`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686e4a037d008323bb6a6339f7c592e1