### PR TITLE
Implement UTM toggle in Flutter UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ class _HomePageState extends State<HomePage> {
   bool _lanScanning = false;
   final Map<String, int> _progress = {};
   static const int _taskCount = 3; // port, SSL, SPF
+  bool hasUtm = false;
 
 
   Future<void> _runLanScan() async {
@@ -338,6 +339,16 @@ class _HomePageState extends State<HomePage> {
                 'Ping ${_speed!.pingMs.toStringAsFixed(1)} ms',
               ),
             ],
+            SwitchListTile(
+              title: const Text('UTMを導入していますか？'),
+              subtitle: const Text('導入済みの場合、セキュリティスコアに加点されます'),
+              value: hasUtm,
+              onChanged: (value) {
+                setState(() {
+                  hasUtm = value;
+                });
+              },
+            ),
             const SizedBox(height: 8),
             ElevatedButton(
               onPressed: _saveReportFile,


### PR DESCRIPTION
## Summary
- track whether UTM is installed
- add SwitchListTile to let the user toggle UTM deployment status

## Testing
- `pytest -q` *(fails: fixture 'mock_scan' not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5810c2ac8323b40be22846fc9e8e