### PR TITLE
Add Windows version section to results

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -112,6 +112,21 @@ Future<NetworkSpeed?> measureNetworkSpeed() async {
   }
 }
 
+/// Detects the Windows version of the current system using ``os_version.py``.
+/// Returns ``null`` on non-Windows or when detection fails.
+Future<String?> getWindowsVersion() async {
+  const script = 'os_version.py';
+  try {
+    final result = await Process.run(pythonExecutable, [script]);
+    if (result.exitCode != 0) return null;
+    final output = result.stdout.toString().trim();
+    if (output.isEmpty || output == 'Non-Windows') return null;
+    return output;
+  } catch (_) {
+    return null;
+  }
+}
+
 /// Runs the bundled Python script using `nmap` to scan [ports] on [host].
 /// Returns a [PortScanSummary] containing all results.
 Future<PortScanSummary> scanPorts(String host, [List<int>? ports]) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -169,7 +169,8 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  void _openResultPage() {
+  Future<void> _openResultPage() async {
+    final version = await diag.getWindowsVersion();
     final items = [
       const DiagnosticItem(
         name: 'ポート開放',
@@ -297,6 +298,7 @@ class _HomePageState extends State<HomePage> {
           lanDevices: lanDevices,
           externalComms: externalComms,
           defenseStatus: defenseStatus,
+          windowsVersion: version ?? '',
         ),
       ),
     );

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -39,6 +39,7 @@ class DiagnosticResultPage extends StatelessWidget {
   final List<LanDeviceRisk> lanDevices;
   final List<ExternalCommInfo> externalComms;
   final List<DefenseFeatureStatus> defenseStatus;
+  final String windowsVersion;
 
   const DiagnosticResultPage({
     super.key,
@@ -53,6 +54,7 @@ class DiagnosticResultPage extends StatelessWidget {
     this.lanDevices = const [],
     this.externalComms = const [],
     this.defenseStatus = const [],
+    this.windowsVersion = '',
   });
 
   Color _scoreColor(int score) {
@@ -380,6 +382,18 @@ class DiagnosticResultPage extends StatelessWidget {
     );
   }
 
+  Widget _windowsVersionSection() {
+    if (windowsVersion.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Windows バージョン'),
+        const SizedBox(height: 4),
+        Text(windowsVersion),
+      ],
+    );
+  }
+
   Future<void> _saveReport(BuildContext context) async {
     try {
       final result = await Process.run(
@@ -507,6 +521,8 @@ class DiagnosticResultPage extends StatelessWidget {
               _externalCommSection(),
               const SizedBox(height: 16),
               _defenseSection(),
+              const SizedBox(height: 16),
+              _windowsVersionSection(),
               const SizedBox(height: 16),
               Align(
                 alignment: Alignment.center,

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -92,6 +92,7 @@ void main() {
     const defense = [
       DefenseFeatureStatus(feature: 'Firewall', status: 'recommended', comment: '')
     ];
+    const version = 'Windows 10';
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -106,6 +107,7 @@ void main() {
           lanDevices: devices,
           externalComms: comms,
           defenseStatus: defense,
+          windowsVersion: version,
         ),
       ),
     );
@@ -117,5 +119,7 @@ void main() {
     expect(find.text('LAN内デバイス一覧とリスクチェック'), findsOneWidget);
     expect(find.text('外部通信の暗号化状況'), findsOneWidget);
     expect(find.text('端末の防御機能の有効性チェック'), findsOneWidget);
+    expect(find.text('Windows バージョン'), findsOneWidget);
+    expect(find.text(version), findsOneWidget);
   });
 }

--- a/test/test_lan_port_scan.py
+++ b/test/test_lan_port_scan.py
@@ -28,12 +28,12 @@ class LanPortScanJsonTest(unittest.TestCase):
 
 @patch('lan_port_scan.run_scan')
 @patch('lan_port_scan._run_arp_scan')
-def test_ipv6_hosts(self, mock_arp, mock_scan):
+def test_ipv6_hosts(mock_arp, mock_scan):
     mock_arp.return_value = [{'ip': 'fe80::1', 'mac': 'aa', 'vendor': 'X'}]
     mock_scan.return_value = []
     res = lan_port_scan.scan_hosts('fe80::/64', ['80'])
     mock_scan.assert_called_with('fe80::1', ['80'], service=False, os_detect=False, scripts=None)
-    self.assertEqual(res[0]['ip'], 'fe80::1')
+    assert res[0]['ip'] == 'fe80::1'
 
 
 class FakeFuture:


### PR DESCRIPTION
## Summary
- add `getWindowsVersion` in diagnostics library
- display scanned Windows version in DiagnosticResultPage
- gather Windows version in HomePage before opening results
- update widget tests for new section
- fix typo in IPv6 test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e583e4fb08323a86dac6d08567fb7