### PR TITLE
Fix BuildContext usage after async awaits

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -172,6 +172,7 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _openResultPage() async {
     final version = await diag.getWindowsVersion();
+    if (!mounted) return;
     final items = [
       const DiagnosticItem(
         name: 'ポート開放',

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -423,10 +423,10 @@ class DiagnosticResultPage extends StatelessWidget {
       if (!context.mounted) return;
 
       final nodes = await _parseSvgNodes(path);
+      if (!context.mounted) return;
       final controller = TransformationController();
 
       await showDialog(
-        // ignore: use_build_context_synchronously
         context: context,
         builder: (_) => Dialog(
           child: SizedBox(


### PR DESCRIPTION
## Summary
- avoid using context when the widget is unmounted after awaits
- remove lint ignore for `use_build_context_synchronously`

## Testing
- `pytest -q`
- `flutter test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f74ea1883239da1093ff9652ce3