### PR TITLE
Add reverse DNS to SPF checks

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -171,7 +171,7 @@ Future<void> _openGeoipPageWithFreshScan() async {
         return value;
       });
       final domain = d.name;
-      final spfFuture = diag.checkSpfRecord(domain).then((value) {
+      final spfFuture = diag.checkSpfRecord(ip).then((value) {
         setState(() {
           _progress[ip] = (_progress[ip] ?? 0) + 1;
           completedTasks++;


### PR DESCRIPTION
## Summary
- resolve hostnames using reverse DNS before SPF queries
- store the resolved domain in `SpfResult`

## Testing
- `PYTHONPATH=. pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e71301dfc83239c06e8b9491e69e2