### PR TITLE
Remove advisory text under security score

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -64,12 +64,6 @@ class DiagnosticResultPage extends StatelessWidget {
     return Colors.redAccent;
   }
 
-  String _scoreMessage(int score) {
-    if (score >= 8) return '社内ネットワークは安全です';
-    if (score >= 5) return '注意が必要です';
-    return '危険な状態です';
-  }
-
   Widget _scoreSection(String label, int score) {
     final color = _scoreColor(score);
     IconData icon;
@@ -104,8 +98,6 @@ class DiagnosticResultPage extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 4),
-        Text(_scoreMessage(score)),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- remove `_scoreMessage` that showed comments like "社内ネットワークは安全です"
- no longer display advisory text below the security score

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e77f0b3748323849db61849005bd8