### PR TITLE
Fix tests and parsing issues

### DIFF
--- a/external_ip_report.py
+++ b/external_ip_report.py
@@ -125,8 +125,9 @@ def main():
     args = parser.parse_args()
 
     if psutil is None:
-        print("psutil module not available")
-        return
+        if not args.json:
+            print("psutil module not available")
+            return
 
     reader = None
     if geoip2 is not None:

--- a/security_report.py
+++ b/security_report.py
@@ -9,7 +9,8 @@ from report_utils import calc_utm_items
 def parse_args(argv):
     if len(argv) < 8:
         print(
-            "Usage: security_report.py <ip> <open_ports_csv> <ssl_valid> <spf_valid> <dkim_valid> <dmarc_valid> <geoip>",
+            "Usage: security_report.py <ip> <open_ports_csv> <ssl_valid> "
+            "<spf_valid> <dkim_valid> <dmarc_valid> <geoip>",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -20,12 +21,17 @@ def parse_args(argv):
     dkim_valid = argv[5].lower() in {"1", "true", "yes"}
     dmarc_valid = argv[6].lower() in {"1", "true", "yes"}
     geoip = argv[7]
-    return ip, ports, ssl_valid, spf_valid, dkim_valid, dmarc_valid, geoip
+    return ip, ports, ssl_status, spf_valid, dkim_valid, dmarc_valid, geoip
 
 
-
-
-def calc_score(open_ports, ssl_valid, spf_valid, dkim_valid, dmarc_valid, geoip):
+def calc_score(
+    open_ports,
+    ssl_status,
+    spf_valid,
+    dkim_valid,
+    dmarc_valid,
+    geoip,
+):
     """Compatibility wrapper for CLI usage."""
 
     risks = []
@@ -91,14 +97,14 @@ def main(argv):
     (
         ip,
         ports,
-        ssl_valid,
+        ssl_status,
         spf_valid,
         dkim_valid,
         dmarc_valid,
         geoip,
     ) = parse_args(argv)
     score, risks, utm_items = calc_score(
-        ports, ssl_valid, spf_valid, dkim_valid, dmarc_valid, geoip
+        ports, ssl_status, spf_valid, dkim_valid, dmarc_valid, geoip
     )
     result = {
         "ip": ip,

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -2,7 +2,6 @@ import unittest
 from security_score import (
     calc_security_score,
     HIGH_WEIGHT,
-    MEDIUM_WEIGHT,
     LOW_WEIGHT,
 )
 

--- a/verify_domain_sender.py
+++ b/verify_domain_sender.py
@@ -2,16 +2,9 @@
 import argparse
 import json
 import subprocess
-import re
 from typing import List
 
 import dns_records
-
-from dns_records import (
-    get_spf_record,
-    get_dkim_record,
-    get_dmarc_record,
-)
 
 
 def lookup_spf(domain: str) -> str:


### PR DESCRIPTION
## Summary
- handle `psutil` being missing when JSON output requested
- fix wrong variable names in `security_report` parser and scoring
- clean up unused imports in `verify_domain_sender`
- remove unused constant from `test_security_score`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7f84f7b48323962fe99a5a032db2