### PR TITLE
Fix score conversion in device list

### DIFF
--- a/lib/device_list_page.dart
+++ b/lib/device_list_page.dart
@@ -30,12 +30,12 @@ class DeviceListPage extends StatelessWidget {
     for (final d in devices) {
       final rep =
           reports.firstWhere((r) => r.ip == d.ip, orElse: () => const SecurityReport('', 0, [], [], '', openPorts: [], geoip: ''));
-      final status = _riskState(rep.score);
+      final status = _riskState(rep.score.toInt());
       final comment = rep.risks.isNotEmpty ? rep.risks.first.description : '';
       rows.add(
         DataRow(
           color: MaterialStateProperty.all(
-            _scoreColor(rep.score).withOpacity(0.2),
+            _scoreColor(rep.score.toInt()).withOpacity(0.2),
           ),
           cells: [
             DataCell(Text(d.ip)),


### PR DESCRIPTION
## Summary
- fix `double` to `int` conversion when displaying device scores

## Testing
- `pytest -q` *(fails: CalcScoreTest fails)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e83305850832380e83f3c63e4e9e2