### PR TITLE
Fix tests expecting reversed security score

### DIFF
--- a/test/test_security_report.py
+++ b/test/test_security_report.py
@@ -9,13 +9,13 @@ from security_report import calc_score
 class CalcScoreTest(unittest.TestCase):
     def test_all_safe(self):
         score, risks, utm = calc_score([], True, True, True, True, 'JP')
-        self.assertEqual(score, 0.0)
+        self.assertEqual(score, 10.0)
         self.assertEqual(risks, [])
         self.assertEqual(utm, [])
 
     def test_high_risk_port_and_invalids(self):
-        score, risks, utm = calc_score(['3389'], False, False, False, False, 'RU')
-        self.assertAlmostEqual(score, 7.0, places=1)
+        score, risks, utm = calc_score(['3389'], 'self-signed', False, False, False, 'RU')
+        self.assertAlmostEqual(score, 5.7, places=1)
         self.assertEqual(len(risks), 6)
         self.assertTrue(all('risk' in r and 'counter' in r for r in risks))
         self.assertEqual(utm, ['firewall', 'web_filter'])
@@ -23,7 +23,7 @@ class CalcScoreTest(unittest.TestCase):
     def test_many_open_ports(self):
         ports = [str(i) for i in range(1, 11)]
         score, risks, utm = calc_score(ports, True, True, True, True, 'JP')
-        self.assertAlmostEqual(score, 5.0, places=1)
+        self.assertAlmostEqual(score, 9.5, places=1)
         self.assertTrue(risks)
         self.assertTrue(all('counter' in r for r in risks))
         self.assertEqual(utm, ['firewall'])


### PR DESCRIPTION
## Summary
- update `test_security_report` expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f42df30f48323a1af5df42aaa65a2