### PR TITLE
Fix result_page imports and port section

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -5,8 +5,7 @@ import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/ssl_check_section.dart';
 import 'package:nwc_densetsu/device_list_page.dart';
 import 'package:nwc_densetsu/network_scan.dart' show NetworkDevice;
-import 'package:nwc_densetsu/utils/report_utils.dart'
-    show generateTopologyDiagram;
+import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 
@@ -736,7 +735,7 @@ class DiagnosticResultPage extends StatelessWidget {
             SslCheckSection(results: sslEntries),
             const SizedBox(height: 16),
           ],
-          _portStatusSection(),
+          _portSection(),
           const SizedBox(height: 16),
           _lanDevicesSection(context),
           const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- alias report_utils import in `result_page.dart`
- call `_portSection()` from `DiagnosticResultPage.build`

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5873f0f48323aa2cab1395c0b2c8