### PR TITLE
Add dangerPortNotes for port warnings

### DIFF
--- a/lib/port_constants.dart
+++ b/lib/port_constants.dart
@@ -24,3 +24,13 @@ const List<int> fullPorts = [
   5900,
   8080,
 ];
+
+/// Notes for ports that are often targeted by attackers.
+///
+/// If a scanned device has any of these ports open, the corresponding
+/// description can be shown in the UI as a warning message.
+const Map<int, String> dangerPortNotes = {
+  3389: 'RDP ポートが開いていると乗っ取りの恐れがあります',
+  445: 'SMB ポートは脆弱性悪用の標的となりやすいです',
+  23: 'Telnet は暗号化されないため危険です',
+};

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -4,6 +4,7 @@ import 'config.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'extended_results.dart';
+import 'port_constants.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 
@@ -186,7 +187,7 @@ class DiagnosticResultPage extends StatelessWidget {
                 for (final r in s.results)
                   DataRow(
                     color: MaterialStateProperty.all(
-                      r.state == 'open' && _dangerPortNotes.containsKey(r.port)
+                      r.state == 'open' && dangerPortNotes.containsKey(r.port)
                           ? Colors.redAccent.withOpacity(0.2)
                           : r.state == 'open'
                               ? Colors.green.withOpacity(0.2)
@@ -196,14 +197,14 @@ class DiagnosticResultPage extends StatelessWidget {
                       DataCell(Text(r.port.toString())),
                       DataCell(Text(
                         r.state == 'open'
-                            ? (_dangerPortNotes.containsKey(r.port)
+                            ? (dangerPortNotes.containsKey(r.port)
                                 ? '危険（開いている）'
                                 : '安全（開いている）')
                             : '安全（閉じている）',
                       )),
                       DataCell(
-                        _dangerPortNotes[r.port] != null
-                            ? Text(_dangerPortNotes[r.port]!)
+                        dangerPortNotes[r.port] != null
+                            ? Text(dangerPortNotes[r.port]!)
                             : const Text('-'),
                       ),
                     ],


### PR DESCRIPTION
## Summary
- define a map of high‑risk ports in `port_constants.dart`
- import and use this map in `result_page.dart` so dangerous ports are highlighted

## Testing
- `pytest -q`
- ❌ `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbb80e5ec83239b1f1ece63088221