### PR TITLE
Consolidate danger port constant

### DIFF
--- a/lib/danger_ports.dart
+++ b/lib/danger_ports.dart
@@ -1,9 +1,0 @@
-/// Warning messages for high-risk ports.
-///
-/// The keys are port numbers and the values explain why the port is
-/// considered dangerous when open.
-const Map<int, String> dangerPortNotes = {
-  3389: 'RDP ポートが開いていると乗っ取りの恐れがあります',
-  445: 'SMB ポートは脆弱性悪用の標的となりやすいです',
-  23: 'Telnet は暗号化されないため危険です',
-};

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -4,7 +4,7 @@ import 'config.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'extended_results.dart';
-import 'danger_ports.dart';
+import 'port_constants.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
 


### PR DESCRIPTION
## Summary
- remove duplicate `dangerPortNotes`
- import the unified constant from `port_constants.dart`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc937aa988323abbf8055a2eb1958