### PR TITLE
Remove port diagnostic item

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -175,12 +175,6 @@ class _HomePageState extends State<HomePage> {
     if (!mounted) return;
     final items = [
       const DiagnosticItem(
-        name: 'ポート開放',
-        description: '不要なポートが開いています',
-        status: 'warning',
-        action: '不要なポートを閉じる',
-      ),
-      const DiagnosticItem(
         name: 'SSL 証明書',
         description: '証明書の有効期限切れ',
         status: 'danger',


### PR DESCRIPTION
## Summary
- drop the "ポート開放" entry from `_openResultPage`
- keep displaying the port table

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2c98a8483239a5dbcebccffc3ca