### PR TITLE
Adjust weights and handle LAN risks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ python lan_port_scan.py --subnet 192.168.1.0/24 --ports 22,80 --service --os
 
 ## セキュリティスコア計算
 
-`security_score.py` スクリプトはポート数や GeoIP、UPnP など複数の指標をまとめた
-JSON を読み込み、10.0 を満点とするセキュリティスコアを計算します。値が小さいほど危険度が高いことを示します。入力例は以下の通りです。
+`security_score.py` スクリプトはポート数や GeoIP、UPnP の有無に加え、ファイアウォール状態や OS の種類、
+ARP スプーフィングや複数 DHCP サーバといった LAN リスクも含めた
+複数の指標をまとめた JSON を読み込み、10.0 を満点とするセキュリティスコアを計算します。値が小さいほど危険度が高いことを示します。入力例は以下の通りです。
 
 ```json
 [
@@ -166,9 +167,9 @@ RDP ポート (3389) が開いている、またはロシアなど危険国と�
 各定数のデフォルト値は `security_score.py` で次のように定義されています。
 
 ```python
-HIGH_WEIGHT = 0.7
-MEDIUM_WEIGHT = 0.3
-LOW_WEIGHT = 0.2
+HIGH_WEIGHT = 4.5
+MEDIUM_WEIGHT = 1.7
+LOW_WEIGHT = 0.5
 ```
 数値が小さいほどリスクが高く、0 から 10 の範囲に丸められます。
 

--- a/test/html_report_test.py
+++ b/test/html_report_test.py
@@ -16,7 +16,7 @@ class HtmlReportGeneratorTest(unittest.TestCase):
         self.assertTrue(html.startswith("<html>"))
         self.assertIn("<table>", html)
         self.assertIn("<td>dev1</td>", html)
-        self.assertIn("<td>9.8</td>", html)  # score for dev1
+        self.assertIn("<td>9.5</td>", html)  # score for dev1
         self.assertTrue(html.endswith("</html>"))
 
 

--- a/test/test_security_report.py
+++ b/test/test_security_report.py
@@ -15,15 +15,15 @@ class CalcScoreTest(unittest.TestCase):
 
     def test_high_risk_port_and_invalids(self):
         score, risks, utm = calc_score(['3389'], 'invalid', False, 'RU')
-        self.assertAlmostEqual(score, 7.0, places=1)
+        self.assertAlmostEqual(score, 0.0, places=1)
         self.assertEqual(len(risks), 4)
         self.assertTrue(all('risk' in r and 'counter' in r for r in risks))
-        self.assertEqual(utm, ['firewall', 'web_filter'])
+        self.assertEqual(utm, ['firewall', 'ips', 'web_filter'])
 
     def test_many_open_ports(self):
         ports = [str(i) for i in range(1, 11)]
         score, risks, utm = calc_score(ports, 'valid', True, 'JP')
-        self.assertAlmostEqual(score, 9.7, places=1)
+        self.assertAlmostEqual(score, 8.3, places=1)
         self.assertTrue(risks)
         self.assertTrue(all('counter' in r for r in risks))
         self.assertEqual(utm, ['firewall'])

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -18,7 +18,7 @@ class CalcSecurityTest(unittest.TestCase):
     def test_single_high(self):
         res = calc_security_score({"danger_ports": ["3389"]})
         self.assertEqual(res["high_risk"], 1)
-        self.assertAlmostEqual(res["score"], 9.3, places=1)
+        self.assertAlmostEqual(res["score"], 5.5, places=1)
 
     def test_mixed_levels(self):
         data = {"danger_ports": 1, "ssl": "invalid", "open_port_count": 2}
@@ -26,8 +26,19 @@ class CalcSecurityTest(unittest.TestCase):
         self.assertEqual(res["high_risk"], 2)
         self.assertEqual(res["medium_risk"], 0)
         self.assertEqual(res["low_risk"], 1)
-        expected = 10 - 1.4 - 0.2
+        expected = 10 - 2 * HIGH_WEIGHT - 1 * LOW_WEIGHT
         self.assertAlmostEqual(res["score"], expected, places=1)
+
+    def test_new_metrics(self):
+        data = {
+            "firewall_enabled": False,
+            "defender_enabled": False,
+            "os_version": "Windows XP",
+            "smbv1": True,
+        }
+        res = calc_security_score(data)
+        self.assertEqual(res["high_risk"], 4)
+        self.assertEqual(res["score"], 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retune HIGH/MEDIUM/LOW weights to 4.5/1.7/0.5
- count LAN diagnostics like ARP spoofing, DHCP and NetBIOS in score
- document new scoring and LAN metrics
- update tests for the revised scoring logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e61fc49888323a6b7beb63a161524