### PR TITLE
Fix duplicated SSL certificate section

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -173,14 +173,7 @@ class _HomePageState extends State<HomePage> {
   Future<void> _openResultPage() async {
     final version = await diag.getWindowsVersion();
     if (!mounted) return;
-    final items = [
-      const DiagnosticItem(
-        name: 'SSL 証明書',
-        description: '証明書の有効期限切れ',
-        status: 'danger',
-        action: '証明書を更新する',
-      ),
-    ];
+    final items = <DiagnosticItem>[];
 
     final sslChecks = <SslCheck>[];
     _sslResults.forEach((host, res) {

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -225,6 +225,10 @@ class DiagnosticResultPage extends StatelessWidget {
       children: [
         const Text('SSL証明書の安全性チェック'),
         const SizedBox(height: 4),
+        const Text('証明書の有効期限切れ'),
+        const SizedBox(height: 4),
+        const Text('推奨対策: 証明書を更新する'),
+        const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('ドメイン')),
           DataColumn(label: Text('発行者')),


### PR DESCRIPTION
## Summary
- remove the DiagnosticItem for SSL certificates
- consolidate SSL certificate info into a single section

## Testing
- `flutter test` *(fails: flutter not installed)*
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdcb1abe083238a10e1b26601351e