### PR TITLE
Show domain sender auth section

### DIFF
--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -112,9 +112,12 @@ void main() {
 
   testWidgets('SPF table rows use colors based on status', (tester) async {
     const results = [
-      SpfResult('ok.com', 'v=spf1 -all', 'safe', ''),
-      SpfResult('none.com', '', 'danger', 'missing'),
-      SpfResult('fail.com', '', 'warning', 'error'),
+      SpfResult('ok.com', 'v=spf1 -all', 'safe', '',
+          dkimValid: true, dmarcValid: true),
+      SpfResult('none.com', '', 'danger', 'missing',
+          dkimValid: false, dmarcValid: false),
+      SpfResult('fail.com', 'v=spf1 -all', 'safe', '',
+          dkimValid: true, dmarcValid: false),
     ];
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- add "ドメインの送信元検証設定" table on result page
- highlight SPF/DKIM/DMARC presence with 〇/× and color-coded status
- update tests for new table

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest discover -s test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd565937c83238c552ff4e2b983d8