### PR TITLE
Add DefenseStatus UI

### DIFF
--- a/lib/defense_check_section.dart
+++ b/lib/defense_check_section.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+/// Section widget that displays Defender and Firewall status.
+class DefenseCheckSection extends StatelessWidget {
+  final bool? defenderEnabled;
+  final bool? firewallEnabled;
+
+  const DefenseCheckSection({
+    super.key,
+    required this.defenderEnabled,
+    required this.firewallEnabled,
+  });
+
+  DataRow _row(String name, bool? enabled, String comment) {
+    Color? rowColor;
+    TextStyle? textStyle;
+    String state;
+    if (enabled == null) {
+      state = '不明';
+    } else if (enabled) {
+      state = '有効';
+      rowColor = Colors.green.withOpacity(0.2);
+      textStyle = const TextStyle(color: Colors.green);
+    } else {
+      state = '無効';
+      rowColor = Colors.redAccent.withOpacity(0.2);
+      textStyle = const TextStyle(color: Colors.red, fontWeight: FontWeight.bold);
+    }
+    return DataRow(
+      color: rowColor != null ? MaterialStateProperty.all(rowColor) : null,
+      cells: [
+        DataCell(Text(name)),
+        DataCell(Text(state, style: textStyle)),
+        DataCell(Text(comment)),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (defenderEnabled == null && firewallEnabled == null) {
+      return const SizedBox.shrink();
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '端末の防御機能の有効性チェック',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'リアルタイム保護やファイアウォールが無効な状態では、マルウェア感染や外部からの侵入を防ぐことができず、端末が極めて無防備になります。基本的なセキュリティ機能が適切に動作しているかを確認してください。',
+        ),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('保護機能')),
+              DataColumn(label: Text('状態')),
+              DataColumn(label: Text('コメント')),
+            ],
+            rows: [
+              _row(
+                'リアルタイム保護（Defender）',
+                defenderEnabled,
+                'ウイルスを検知し自動隔離します。無効だと脅威を見逃します。',
+              ),
+              _row(
+                '外部アクセス遮断（Firewall）',
+                firewallEnabled,
+                '外部からの不正アクセスを遮断します。無効では侵入リスクが高まります。',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -73,6 +73,13 @@ class NetworkSpeed {
   const NetworkSpeed(this.downloadMbps, this.uploadMbps, this.pingMs);
 }
 
+class DefenseStatus {
+  final bool? defenderEnabled;
+  final bool? firewallEnabled;
+
+  const DefenseStatus({this.defenderEnabled, this.firewallEnabled});
+}
+
 /// Runs the system ping command.
 Future<String> runPing([String host = 'google.com']) async {
   final args = Platform.isWindows ? ['-n', '4', host] : ['-c', '4', host];
@@ -99,6 +106,32 @@ Future<NetworkSpeed?> measureNetworkSpeed() async {
     return NetworkSpeed(down, up, ping);
   } catch (_) {
     return null;
+  }
+}
+
+/// Checks Defender and firewall status using `firewall_check.py`.
+Future<DefenseStatus> checkDefenseStatus() async {
+  const script = 'firewall_check.py';
+  try {
+    final result = await Process.run('python', [script]);
+    if (result.exitCode != 0) {
+      return const DefenseStatus();
+    }
+    final data = jsonDecode(result.stdout.toString()) as Map<String, dynamic>;
+    bool? _parse(dynamic v) {
+      if (v == null) return null;
+      if (v is bool) return v;
+      final s = v.toString().toLowerCase();
+      if (['true', '1', 'yes'].contains(s)) return true;
+      if (['false', '0', 'no'].contains(s)) return false;
+      return null;
+    }
+    return DefenseStatus(
+      defenderEnabled: _parse(data['defender_enabled']),
+      firewallEnabled: _parse(data['firewall_enabled']),
+    );
+  } catch (_) {
+    return const DefenseStatus();
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ class _HomePageState extends State<HomePage> {
   List<SecurityReport> _reports = [];
   List<SpfResult> _spfResults = [];
   diag.NetworkSpeed? _speed;
+  diag.DefenseStatus? _defense;
   bool _lanScanning = false;
   String _portPreset = 'default';
   final Map<String, int> _progress = {};
@@ -86,6 +87,8 @@ class _HomePageState extends State<HomePage> {
 
     final speed = await diag.measureNetworkSpeed();
     setState(() => _speed = speed);
+    final defense = await diag.checkDefenseStatus();
+    setState(() => _defense = defense);
     final buffer = StringBuffer();
     if (speed != null) {
       buffer.writeln('--- Network Speed ---');
@@ -263,6 +266,8 @@ class _HomePageState extends State<HomePage> {
           items: items,
           portSummaries: _scanResults,
           spfResults: _spfResults,
+          defenderEnabled: _defense?.defenderEnabled,
+          firewallEnabled: _defense?.firewallEnabled,
         ),
       ),
     );

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -5,6 +5,7 @@ import 'package:nwc_densetsu/utils/report_utils.dart'
     show generateTopologyDiagram;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xml/xml.dart' as xml;
+import 'package:nwc_densetsu/defense_check_section.dart';
 
 const Map<int, String> _dangerPortNotes = {
   3389: 'リモートデスクトップ接続が可能なため、攻撃の対象になりやすい',
@@ -39,6 +40,8 @@ class DiagnosticResultPage extends StatelessWidget {
   final List<DiagnosticItem> items;
   final List<PortScanSummary> portSummaries;
   final List<SpfResult> spfResults;
+  final bool? defenderEnabled;
+  final bool? firewallEnabled;
   final Future<String> Function()? onGenerateTopology;
 
   const DiagnosticResultPage({
@@ -48,6 +51,8 @@ class DiagnosticResultPage extends StatelessWidget {
     required this.items,
     this.portSummaries = const [],
     this.spfResults = const [],
+    this.defenderEnabled,
+    this.firewallEnabled,
     this.onGenerateTopology,
   });
 
@@ -241,6 +246,13 @@ class DiagnosticResultPage extends StatelessWidget {
     );
   }
 
+  Widget _defenseSection() {
+    return DefenseCheckSection(
+      defenderEnabled: defenderEnabled,
+      firewallEnabled: firewallEnabled,
+    );
+  }
+
   Future<void> _saveReport(BuildContext context) async {
     try {
       final result = await Process.run(
@@ -326,6 +338,8 @@ class DiagnosticResultPage extends StatelessWidget {
             _portStatusSection(),
             const SizedBox(height: 16),
             _spfSection(),
+            const SizedBox(height: 16),
+            _defenseSection(),
             const SizedBox(height: 16),
             Expanded(
               child: ListView.builder(

--- a/test/defense_check_section_test.dart
+++ b/test/defense_check_section_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwc_densetsu/defense_check_section.dart';
+
+void main() {
+  testWidgets('DefenseCheckSection shows statuses', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: DefenseCheckSection(
+            defenderEnabled: true,
+            firewallEnabled: false,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('端末の防御機能の有効性チェック'), findsOneWidget);
+    expect(find.text('リアルタイム保護（Defender）'), findsOneWidget);
+    expect(find.text('外部アクセス遮断（Firewall）'), findsOneWidget);
+    expect(find.text('有効'), findsOneWidget);
+    expect(find.text('無効'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- create DefenseCheckSection widget for Defender and Firewall statuses
- embed the new section in DiagnosticResultPage
- clarify table labels and comments for better readability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `flutter test test/defense_check_section_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bd8ab49d483239f341ec16ca0b98b