### PR TITLE
Add clearer Python failure warnings and bundle steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,23 @@ flutter test
 - `generate_html_report.py`
 - `generate_topology.py`
 
+### 配布手順例
+
+1. `flutter build windows` もしくは `flutter build linux` を実行します。
+2. 生成されたバンドルのディレクトリに、リポジトリ直下の `*.py` ファイルをすべて
+   コピーします。
+
+   ```bash
+   # Windows の例
+   cp *.py build/windows/runner/Release/
+
+   # Linux の例
+   cp *.py build/linux/x64/release/bundle/
+   ```
+
+3. 配布先の PC には Python 3.10 以上と `requirements.txt` 記載のライブラリを
+   インストールしてください。
+
 ## 貢献
 
 詳しい貢献方法は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,7 +62,12 @@ class _HomePageState extends State<HomePage> {
       _progress.clear();
     });
 
-    final speed = await diag.measureNetworkSpeed();
+    final speed = await diag.measureNetworkSpeed(onError: (msg) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('速度計測失敗: $msg')));
+      }
+    });
     setState(() => _speed = speed);
     final buffer = StringBuffer();
     if (speed != null) {
@@ -97,7 +102,13 @@ class _HomePageState extends State<HomePage> {
       final pingRes = await diag.runPing(ip);
       buffer.writeln(pingRes);
 
-      final portFuture = diag.scanPorts(ip).then((value) {
+      final portFuture = diag
+          .scanPorts(ip, onError: (msg) {
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text('ポートスキャン失敗: $msg')));
+        }
+      }).then((value) {
         setState(() => _progress[ip] = (_progress[ip] ?? 0) + 1);
         return value;
       });
@@ -171,7 +182,12 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _openResultPage() async {
-    final version = await diag.getWindowsVersion();
+    final version = await diag.getWindowsVersion(onError: (msg) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Windows情報取得失敗: $msg')));
+      }
+    });
     if (!mounted) return;
     final items = <DiagnosticItem>[];
 

--- a/lib/network_scan.dart
+++ b/lib/network_scan.dart
@@ -20,10 +20,11 @@ Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}
     final result = await Process.run(pythonExecutable, [script]);
     if (result.exitCode != 0) {
       final msg = result.stderr.toString().trim();
-      stderr.writeln(msg.isEmpty
+      final err = msg.isEmpty
           ? 'LAN discovery script exited with code ${result.exitCode}'
-          : msg);
-      if (onError != null) onError(msg);
+          : msg;
+      stderr.writeln(err);
+      if (onError != null) onError(err);
       return [];
     }
     final output = result.stdout.toString();
@@ -45,8 +46,10 @@ Future<List<NetworkDevice>> scanNetwork({void Function(String message)? onError}
     }
     return devices;
   } catch (e) {
-    stderr.writeln(e);
-    if (onError != null) onError(e.toString());
+    final msg =
+        'Failed to run $script: $e. Ensure Python and required tools are installed.';
+    stderr.writeln(msg);
+    if (onError != null) onError(msg);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- improve error messages when Python scripts fail
- surface those errors in the UI via SnackBars
- clarify how to copy scripts when distributing builds

## Testing
- `pytest -q` *(fails: SyntaxError in security_score.py)*

------
https://chatgpt.com/codex/tasks/task_e_6870b2601e388323a47026391aa6e366