### PR TITLE
Switch UI to monochrome

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,2 +1,7 @@
-const bool useColor = bool.fromEnvironment('NWCD_USE_COLOR', defaultValue: true);
+/// Determines if the UI should be rendered in color.
+///
+/// The default is set to `false` so the application runs in monochrome unless
+/// explicitly overridden via the `NWCD_USE_COLOR` environment variable.
+const bool useColor =
+    bool.fromEnvironment('NWCD_USE_COLOR', defaultValue: false);
 

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -72,6 +72,7 @@ class DiagnosticResultPage extends StatelessWidget {
   }
 
   Color _statusColor(String status) {
+    if (!useColor) return Colors.black;
     switch (status) {
       case 'safe':
         return Colors.green;
@@ -219,13 +220,13 @@ class DiagnosticResultPage extends StatelessWidget {
                 for (final r in s.results)
                   DataRow(
                     color: WidgetStateProperty.all(
-                      r.state == 'open' && dangerPortNotes.containsKey(r.port)
-                          ? Colors.redAccent.withAlpha((0.2 * 255).toInt()) 
-                          : r.state == 'open'
-                              ? Colors.green.withAlpha((0.2 * 255).toInt()) 
-
-                              : Colors.grey.withAlpha((0.2 * 255).toInt()) 
-
+                      useColor
+                          ? r.state == 'open' && dangerPortNotes.containsKey(r.port)
+                              ? Colors.redAccent.withAlpha((0.2 * 255).toInt())
+                              : r.state == 'open'
+                                  ? Colors.green.withAlpha((0.2 * 255).toInt())
+                                  : Colors.grey.withAlpha((0.2 * 255).toInt())
+                          : Colors.grey.withAlpha((0.2 * 255).toInt()),
                     ),
                     cells: [
                       DataCell(Text(r.port.toString())),


### PR DESCRIPTION
## Summary
- default to monochrome design via `useColor`
- respect `useColor` in diagnostic result status
- grey-out port list when monochrome

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f0e9109c8323a3eedbad434d6a2c