### PR TITLE
Link LAN devices to network map

### DIFF
--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -93,4 +93,35 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(SvgPicture), findsOneWidget);
   });
+
+  testWidgets('Tapping device row opens topology', (tester) async {
+    const devices = [
+      LanDeviceRisk(
+          ip: '192.168.1.2',
+          mac: '00:11',
+          vendor: 'Test',
+          name: 'd',
+          status: 'ok',
+          comment: '')
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 4,
+          items: const [],
+          portSummaries: const [],
+          lanDevices: devices,
+          onGenerateTopology: () async {
+            return report_utils.generateTopologyDiagram(devices);
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('192.168.1.2'), findsOneWidget);
+    await tester.tap(find.text('192.168.1.2'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SvgPicture), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- highlight a node in `_showTopology` when an IP is provided and center the view
- allow tapping a LAN device table row to open the topology view with that device preselected
- add a widget test to verify row tapping opens the topology dialog

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0d00e1483238925de0315ae90ee