### PR TITLE
Show LAN device status summary

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -361,11 +361,20 @@ class DiagnosticResultPage extends StatelessWidget {
 
   Widget _lanSection() {
     if (lanDevices.isEmpty) return const SizedBox.shrink();
+    final counts = <String, int>{'safe': 0, 'warning': 0, 'danger': 0};
+    for (final d in lanDevices) {
+      var s = d.status;
+      if (s == 'ok') s = 'safe';
+      if (counts.containsKey(s)) counts[s] = counts[s]! + 1;
+    }
+    final summary =
+        '${counts['safe']} safe / ${counts['warning']} warning / ${counts['danger']} danger';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const Text('LAN内デバイス一覧とリスクチェック'),
         const SizedBox(height: 4),
+        Text(summary),
         DataTable(columns: const [
           DataColumn(label: Text('IPアドレス')),
           DataColumn(label: Text('MACアドレス')),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -127,4 +127,50 @@ void main() {
     expect(find.text('Windows バージョン'), findsOneWidget);
     expect(find.text(version), findsOneWidget);
   });
+
+  testWidgets('LAN device summary shows status counts', (tester) async {
+    const devices = [
+      LanDeviceRisk(
+          ip: '1',
+          mac: 'm1',
+          vendor: 'v',
+          name: 'n1',
+          status: 'safe',
+          comment: ''),
+      LanDeviceRisk(
+          ip: '2',
+          mac: 'm2',
+          vendor: 'v',
+          name: 'n2',
+          status: 'warning',
+          comment: ''),
+      LanDeviceRisk(
+          ip: '3',
+          mac: 'm3',
+          vendor: 'v',
+          name: 'n3',
+          status: 'danger',
+          comment: ''),
+      LanDeviceRisk(
+          ip: '4',
+          mac: 'm4',
+          vendor: 'v',
+          name: 'n4',
+          status: 'danger',
+          comment: ''),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 5,
+          items: [],
+          portSummaries: [],
+          lanDevices: devices,
+        ),
+      ),
+    );
+
+    expect(find.text('1 safe / 1 warning / 2 danger'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- compute counts for each LAN device risk status
- display `safe / warning / danger` totals above the LAN device table
- test status summary rendering

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0c30d008323ad8a29ecc39ed1da