### PR TITLE
Support UTM bonus in security score

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -275,6 +275,7 @@ Future<SecurityReport> runSecurityReport({
   required List<int> openPorts,
   required bool sslValid,
   required bool spfValid,
+  bool utmActive = false,
   String geoip = 'JP',
   ProcessRunner processRunner = _defaultRunner,
 }) async {
@@ -287,6 +288,7 @@ Future<SecurityReport> runSecurityReport({
       sslValid ? 'true' : 'false',
       spfValid ? 'true' : 'false',
       geoip,
+      utmActive ? 'true' : 'false',
     ]);
     final output = result.stdout.toString();
     if (output.trim().isEmpty) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -145,6 +145,7 @@ class _HomePageState extends State<HomePage> {
         ],
         sslValid: sslRes.valid,
         spfValid: spfRes.startsWith('SPF record'),
+        utmActive: hasUtm,
       );
       _reports.add(report);
       buffer.writeln('Score: ${report.score}');

--- a/security_report.py
+++ b/security_report.py
@@ -7,9 +7,9 @@ from report_utils import calc_utm_items
 
 
 def parse_args(argv):
-    if len(argv) < 6:
+    if len(argv) < 7:
         print(
-            "Usage: security_report.py <ip> <open_ports_csv> <ssl_status> <spf_valid> <geoip>",
+            "Usage: security_report.py <ip> <open_ports_csv> <ssl_status> <spf_valid> <geoip> <utm_active>",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -18,10 +18,11 @@ def parse_args(argv):
     ssl_status = argv[3].lower()
     spf_valid = argv[4].lower() in {"1", "true", "yes"}
     geoip = argv[5]
-    return ip, ports, ssl_status, spf_valid, geoip
+    utm_active = argv[6].lower() in {"1", "true", "yes"}
+    return ip, ports, ssl_status, spf_valid, geoip, utm_active
 
 
-def calc_score(open_ports, ssl_status, spf_valid, geoip):
+def calc_score(open_ports, ssl_status, spf_valid, geoip, utm_active=False):
     """Return score, risk descriptions and UTM items."""
 
     risks = []
@@ -61,6 +62,7 @@ def calc_score(open_ports, ssl_status, spf_valid, geoip):
         "geoip": geoip,
         "ssl": ssl_status,
         "dns_fail_rate": 0.0 if spf_valid else 1.0,
+        "utm_active": utm_active,
     }
 
     res = calc_security_score(data)
@@ -70,8 +72,8 @@ def calc_score(open_ports, ssl_status, spf_valid, geoip):
 
 
 def main(argv):
-    ip, ports, ssl_status, spf_valid, geoip = parse_args(argv)
-    score, risks, utm_items = calc_score(ports, ssl_status, spf_valid, geoip)
+    ip, ports, ssl_status, spf_valid, geoip, utm_active = parse_args(argv)
+    score, risks, utm_items = calc_score(ports, ssl_status, spf_valid, geoip, utm_active)
     result = {
         "ip": ip,
         "score": score,

--- a/security_score.py
+++ b/security_score.py
@@ -13,6 +13,7 @@ from common_constants import DANGER_COUNTRIES, SAFE_COUNTRIES
 HIGH_WEIGHT = 4.5
 MEDIUM_WEIGHT = 1.7
 LOW_WEIGHT = 0.5
+UTM_BONUS = 2.0
 
 __all__ = ["calc_security_score"]
 
@@ -138,6 +139,8 @@ def calc_security_score(data: Dict[str, Any]) -> Dict[str, Any]:
         high += 1
 
     score = 10.0 - high * HIGH_WEIGHT - medium * MEDIUM_WEIGHT - low * LOW_WEIGHT
+    if data.get("utm_active"):
+        score += UTM_BONUS
     score = max(0.0, min(10.0, score))
 
     return {

--- a/test/run_security_report_test.dart
+++ b/test/run_security_report_test.dart
@@ -6,7 +6,9 @@ import 'package:nwc_densetsu/diagnostics.dart';
 
 void main() {
   test('runSecurityReport parses floating score', () async {
+    late List<String> received;
     Future<ProcessResult> fakeRunner(String exe, List<String> args) async {
+      received = args;
       final data = {
         'ip': '1.2.3.4',
         'score': 6.7,
@@ -25,9 +27,11 @@ void main() {
       openPorts: const [],
       sslValid: true,
       spfValid: true,
+      utmActive: true,
       processRunner: fakeRunner,
     );
 
     expect(report.score, 6.7);
+    expect(received.last, 'true');
   });
 }

--- a/test/test_security_score.py
+++ b/test/test_security_score.py
@@ -40,6 +40,14 @@ class CalcSecurityTest(unittest.TestCase):
         self.assertEqual(res["high_risk"], 4)
         self.assertEqual(res["score"], 0.0)
 
+    def test_utm_bonus(self):
+        data = {"danger_ports": ["3389"], "utm_active": True}
+        res = calc_security_score(data)
+        expected = 10 - HIGH_WEIGHT + 2.0
+        if expected > 10:
+            expected = 10.0
+        self.assertAlmostEqual(res["score"], expected, places=1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `utmActive` parameter to `runSecurityReport` and propagate it to `security_report.py`
- let `security_score.py` give a 2 point bonus when UTM is active
- update main UI to pass the switch value
- test argument forwarding and scoring

## Testing
- `pytest -q`
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e71e25ec483239c92f87465dc7336