### PR TITLE
Improve port summary UI

### DIFF
--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -48,6 +48,9 @@ void main() {
     expect(find.text('危険（開いている）'), findsOneWidget);
     expect(find.text('445'), findsOneWidget);
     expect(find.text('安全（閉じている）'), findsOneWidget);
+    expect(find.text('rdp'), findsOneWidget);
+    expect(find.text('smb'), findsOneWidget);
+    expect(find.text('1/2 ポート開放'), findsOneWidget);
   });
 
   testWidgets('extended result sections are visible when data provided',

--- a/test/open_result_page_test.dart
+++ b/test/open_result_page_test.dart
@@ -20,5 +20,7 @@ void main() {
 
     expect(find.text('ポート開放状況'), findsOneWidget);
     expect(find.textContaining('80'), findsOneWidget);
+    expect(find.text('http'), findsOneWidget);
+    expect(find.text('1/1 ポート開放'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add service icon helper
- list port services in result table and show open port summary
- move port explanation below table
- add tests for new UI info

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a187ae0883239cd8540d2b2c508f