### PR TITLE
Remove obsolete SPF results table

### DIFF
--- a/lib/extended_results.dart
+++ b/lib/extended_results.dart
@@ -13,19 +13,6 @@ class SslCheck {
       required this.comment});
 }
 
-class SpfCheck {
-  final String domain;
-  final String spf;
-  final String status;
-  final String comment;
-
-  const SpfCheck(
-      {required this.domain,
-      required this.spf,
-      required this.status,
-      required this.comment});
-}
-
 class DomainAuthCheck {
   final String domain;
   final bool spf;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -206,19 +206,6 @@ class _HomePageState extends State<HomePage> {
       ));
     });
 
-    final spfChecks = <SpfCheck>[];
-    _spfResults.forEach((host, res) {
-      final ok = res.startsWith('SPF record');
-      final spf = ok
-          ? res.substring(res.indexOf('SPF record') + 10).trim()
-          : '';
-      spfChecks.add(SpfCheck(
-        domain: host,
-        spf: spf,
-        status: ok ? 'ok' : 'warning',
-        comment: ok ? '' : 'missing',
-      ));
-    });
 
     final domainAuths = <DomainAuthCheck>[];
     _spfResults.forEach((host, res) {
@@ -297,7 +284,6 @@ class _HomePageState extends State<HomePage> {
           items: items,
           portSummaries: _scanResults,
           sslChecks: sslChecks,
-          spfChecks: spfChecks,
           domainAuths: domainAuths,
           geoipStats: geoipStats,
           lanDevices: lanDevices,

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -34,7 +34,6 @@ class DiagnosticResultPage extends StatelessWidget {
   final List<DiagnosticItem> items;
   final Future<String> Function()? onGenerateTopology;
   final List<SslCheck> sslChecks;
-  final List<SpfCheck> spfChecks;
   final List<DomainAuthCheck> domainAuths;
   final List<GeoIpStat> geoipStats;
   final List<LanDeviceRisk> lanDevices;
@@ -49,7 +48,6 @@ class DiagnosticResultPage extends StatelessWidget {
     required this.portSummaries,
     this.onGenerateTopology,
     this.sslChecks = const [],
-    this.spfChecks = const [],
     this.domainAuths = const [],
     this.geoipStats = const [],
     this.lanDevices = const [],
@@ -282,30 +280,6 @@ class DiagnosticResultPage extends StatelessWidget {
     );
   }
 
-  Widget _spfSection() {
-    if (spfChecks.isEmpty) return const SizedBox.shrink();
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('SPFレコードの設定状況'),
-        const SizedBox(height: 4),
-        DataTable(columns: const [
-          DataColumn(label: Text('ドメイン')),
-          DataColumn(label: Text('SPF')),
-          DataColumn(label: Text('状態')),
-          DataColumn(label: Text('コメント')),
-        ], rows: [
-          for (final c in spfChecks)
-            DataRow(cells: [
-              DataCell(Text(c.domain)),
-              DataCell(Text(c.spf)),
-              DataCell(Text(c.status)),
-              DataCell(Text(c.comment)),
-            ]),
-        ]),
-      ],
-    );
-  }
 
   Widget _domainAuthSection() {
     if (domainAuths.isEmpty) return const SizedBox.shrink();
@@ -582,8 +556,6 @@ class DiagnosticResultPage extends StatelessWidget {
               _portSection(),
               const SizedBox(height: 16),
               _sslSection(),
-              const SizedBox(height: 16),
-              _spfSection(),
               const SizedBox(height: 16),
               _domainAuthSection(),
               const SizedBox(height: 16),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -60,13 +60,6 @@ void main() {
           status: 'ok',
           comment: '')
     ];
-    const spf = [
-      SpfCheck(
-          domain: 'example.com',
-          spf: 'v=spf1',
-          status: 'ok',
-          comment: '')
-    ];
     const auth = [
       DomainAuthCheck(
           domain: 'example.com',
@@ -106,7 +99,6 @@ void main() {
           items: [],
           portSummaries: [],
           sslChecks: ssl,
-          spfChecks: spf,
           domainAuths: auth,
           geoipStats: geo,
           lanDevices: devices,
@@ -118,7 +110,6 @@ void main() {
     );
 
     expect(find.text('SSL証明書の安全性チェック'), findsOneWidget);
-    expect(find.text('SPFレコードの設定状況'), findsOneWidget);
     expect(find.text('ドメインの送信元検証設定'), findsOneWidget);
     expect(find.text('GeoIP解析：通信先の国別リスクチェック'), findsOneWidget);
     expect(find.text('LAN内デバイス一覧とリスクチェック'), findsOneWidget);


### PR DESCRIPTION
## Summary
- remove the dedicated SPF record section from results
- drop `SpfCheck` model and references
- adjust result page parameters
- update widget test expectations

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a381c000832388ea05dedf8e1ff7