### PR TITLE
Add security score message

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -143,6 +143,11 @@ class DiagnosticResultPage extends StatelessWidget {
             ],
           ),
         ),
+        const SizedBox(height: 4),
+        Text(
+          _scoreMessage(score),
+          style: TextStyle(color: color),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- connect `_scoreMessage` to the score display in `DiagnosticResultPage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c3e32f8c83238ae376105b71a99a