### PR TITLE
Fix import usage comment

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/diagnostics.dart' as diag;
 import 'package:nwc_densetsu/network_scan.dart' as net;
+// The diagnostics and network_scan libraries are imported with aliases only.
+// Avoid using `show`/`hide` so that all named parameters like `utmActive`
+// remain available during development.
 import 'package:fl_chart/fl_chart.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';


### PR DESCRIPTION
## Summary
- document the reason to avoid show/hide for imports in `main.dart`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743e210c0c832385a0f0cd095e2c9d