### PR TITLE
Increase Windows port header emphasis

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -271,7 +271,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
         children: [
           const Text(
             'ポート開放状況',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.w900),
           ),
         const SizedBox(height: 4),
         const Text(


### PR DESCRIPTION
## Summary
- emphasize the Windows port open status section header

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745a14d1a08323af1224f839ccc99b