### PR TITLE
Adjust port section heading

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -271,7 +271,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
         children: [
           const Text(
             'ポート開放状況',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
           ),
         const SizedBox(height: 4),
         const Text(


### PR DESCRIPTION
## Summary
- enlarge and bold the "ポート開放状況" heading

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68745a0b5ae08323b0479fe372943bd1