### PR TITLE
Increase port status title emphasis

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -271,7 +271,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
         children: [
           const Text(
             'ポート開放状況',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
         const SizedBox(height: 4),
         const Text(


### PR DESCRIPTION
## Summary
- enlarge the "ポート開放状況" heading to improve visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745a05ae0c8323a1b2685edf63e1f5