### PR TITLE
Increase port section header size

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -271,7 +271,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
         children: [
           const Text(
             'ポート開放状況',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.w900),
           ),
         const SizedBox(height: 4),
         const Text(


### PR DESCRIPTION
## Summary
- make the "ポート開放状況" header larger and heavier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687459fe876883239379ccc9e93114fe