### PR TITLE
Enhance port status header

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -271,7 +271,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
         children: [
           const Text(
             'ポート開放状況',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
         const SizedBox(height: 4),
         const Text(


### PR DESCRIPTION
## Summary
- enlarge and bold the "ポート開放状況" section title so it stands out

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687459eb7d2483239fe7518244966120