### PR TITLE
Update port state labels

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -327,15 +327,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
                               )
                             : const Text('-'),
                       ),
-                     DataCell(
-                        Text(
-                          r.state == 'open'
-                              ? (dangerPortNotes.containsKey(r.port)
-                                  ? '危険（開いている）'
-                                  : '安全（開いている）')
-                              : '安全（閉じている）',
-                        ),
-                      ),
+                     DataCell(Text(r.state)),
                       DataCell(
                         dangerPortNotes[r.port] != null
                             ? Text(dangerPortNotes[r.port]!)

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -45,9 +45,9 @@ void main() {
     // Port status section
     expect(find.text('ポート開放状況'), findsOneWidget);
     expect(find.text('3389'), findsOneWidget);
-    expect(find.text('危険（開いている）'), findsOneWidget);
+    expect(find.text('open'), findsOneWidget);
     expect(find.text('445'), findsOneWidget);
-    expect(find.text('安全（閉じている）'), findsOneWidget);
+    expect(find.text('closed'), findsOneWidget);
     expect(find.text('rdp'), findsOneWidget);
     expect(find.text('smb'), findsOneWidget);
     expect(find.text('1/2 ポート開放'), findsOneWidget);


### PR DESCRIPTION
## Summary
- show raw port state in DiagnosticResultPage
- update diagnostic result page test to match new labels

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68747403bbfc83239fafcb02c7e94501