### PR TITLE
Display SSL status in Japanese

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -134,6 +134,26 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
     }
   }
 
+  String _sslStatusText(String status) {
+    switch (status) {
+      case 'ok':
+        return '安全';
+      case 'warning':
+        return '警告';
+      default:
+        return status;
+    }
+  }
+
+  String _sslCommentText(String comment) {
+    switch (comment) {
+      case 'invalid':
+        return '証明書が無効です';
+      default:
+        return comment;
+    }
+  }
+
   IconData _iconForService(String service) {
     const mapping = {
       'http': Icons.http,
@@ -382,8 +402,8 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
               DataCell(Text(c.domain)),
               DataCell(Text(c.issuer)),
               DataCell(Text(c.expiry)),
-              DataCell(Text(c.status)),
-              DataCell(Text(c.comment)),
+              DataCell(Text(_sslStatusText(c.status))),
+              DataCell(Text(_sslCommentText(c.comment))),
             ]),
         ]),
       ],


### PR DESCRIPTION
## Summary
- translate SSL certificate status and comment values to Japanese for result page

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874776570e08323bf11af547bfd4edc