### PR TITLE
Enable vuln script by default in port scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ PDF 生成を行う場合は、`pdfkit` が利用する `wkhtmltopdf` または 
 ```bash
 python port_scan.py <host> [port_list] [--service] [--os] [--script vuln]
 ```
+`--script` を省略した場合は `vuln` スクリプトが自動的に指定され、脆弱性チェックが行われます。
 
 ## LAN デバイス一覧取得
 

--- a/port_scan.py
+++ b/port_scan.py
@@ -24,6 +24,8 @@ def run_scan(
         cmd.append("-sV")
     if os_detect:
         cmd.append("-O")
+    if scripts is None:
+        scripts = ["vuln"]
     if scripts:
         cmd += ["--script", ",".join(scripts)]
     if not ports:
@@ -62,7 +64,10 @@ def main():
     parser.add_argument("port_list", nargs="?", help="Comma separated ports")
     parser.add_argument("--service", action="store_true", help="Enable service version detection (-sV)")
     parser.add_argument("--os", action="store_true", help="Enable OS detection (-O)")
-    parser.add_argument("--script", help="Comma separated nmap scripts")
+    parser.add_argument(
+        "--script",
+        help="Comma separated nmap scripts (default: vuln)",
+    )
     args = parser.parse_args()
 
     ports = args.port_list.split(',') if args.port_list else []

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -10,7 +10,7 @@ class PortScanScriptTest(unittest.TestCase):
             m.return_value = MagicMock(returncode=0, stdout=xml)
             port_scan.run_scan('1.1.1.1', [])
             m.assert_called_with([
-                'nmap', '-p-', '-oX', '-', '1.1.1.1'
+                'nmap', '--script', 'vuln', '-p-', '-oX', '-', '1.1.1.1'
             ], capture_output=True, text=True)
 
     def test_run_scan_with_options(self):
@@ -28,7 +28,16 @@ class PortScanScriptTest(unittest.TestCase):
             m.return_value = MagicMock(returncode=0, stdout=xml)
             port_scan.run_scan('fe80::1', [])
             m.assert_called_with([
-                'nmap', '-6', '-p-', '-oX', '-', 'fe80::1'
+                'nmap', '-6', '--script', 'vuln', '-p-', '-oX', '-', 'fe80::1'
+            ], capture_output=True, text=True)
+
+    def test_run_scan_custom_script_overrides_default(self):
+        xml = "<nmaprun></nmaprun>"
+        with patch('subprocess.run') as m:
+            m.return_value = MagicMock(returncode=0, stdout=xml)
+            port_scan.run_scan('1.1.1.1', [], scripts=['http-enum'])
+            m.assert_called_with([
+                'nmap', '--script', 'http-enum', '-p-', '-oX', '-', '1.1.1.1'
             ], capture_output=True, text=True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- run `nmap --script vuln` automatically when no script is specified in `port_scan.py`
- update command line help and README usage example with vulnerability check info
- extend port scan tests for default script behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687499cf443483239b94e4dcb5d1a716