### PR TITLE
Add local history feature to Flutter app

### DIFF
--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+
+import 'diagnostics.dart';
+import 'utils/report_utils.dart' as report_utils;
+import 'result_page.dart';
+
+class HistoryPage extends StatefulWidget {
+  const HistoryPage({super.key});
+
+  @override
+  State<HistoryPage> createState() => _HistoryPageState();
+}
+
+class _HistoryPageState extends State<HistoryPage> {
+  List<FileSystemEntity> _files = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFiles();
+  }
+
+  Future<void> _loadFiles() async {
+    final dir = Directory(p.join(Directory.current.path, 'history'));
+    if (await dir.exists()) {
+      final list = await dir
+          .list()
+          .where((e) => e.path.endsWith('.json'))
+          .toList();
+      list.sort((a, b) => b.path.compareTo(a.path));
+      setState(() => _files = list);
+    } else {
+      setState(() => _files = []);
+    }
+  }
+
+  Future<void> _openFile(String path) async {
+    final reports = report_utils.loadHistoryReports(path);
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ResultPage(
+          reports: reports,
+          onSave: () async {
+            await report_utils.savePdfReport(reports);
+          },
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: _loadFiles,
+      child: ListView.builder(
+        itemCount: _files.length,
+        itemBuilder: (context, index) {
+          final f = _files[index];
+          final name = p.basename(f.path);
+          return ListTile(
+            title: Text(name),
+            onTap: () => _openFile(f.path),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/extended_results.dart';
+import 'package:nwc_densetsu/history_page.dart';
 import 'config.dart';
 
 void main() {
@@ -20,9 +21,26 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'NWCD',
-      home: HomePage(),
+      home: DefaultTabController(
+        length: 2,
+        child: Scaffold(
+          appBar: AppBar(
+            title: const Text('NWCD'),
+            bottom: const TabBar(tabs: [
+              Tab(text: '診断'),
+              Tab(text: '履歴'),
+            ]),
+          ),
+          body: const TabBarView(
+            children: [
+              HomePage(),
+              HistoryPage(),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }
@@ -158,11 +176,16 @@ class _HomePageState extends State<HomePage> {
       setState(() => _progress.remove(ip));
     }
 
+    final path = await report_utils.saveHistoryReports(_reports);
     setState(() {
       _output = buffer.toString();
       _lanScanning = false;
       _devices = devices;
     });
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('結果保存: $path')));
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- auto-save diagnostic results under `history/` with timestamped JSON
- list saved scans via new `HistoryPage`
- switch main app to tab layout with `History` tab

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687499cbb5b48323b591c8ce32dbc3fc