### PR TITLE
Warn when GeoIP database missing

### DIFF
--- a/external_ip_report.py
+++ b/external_ip_report.py
@@ -93,7 +93,10 @@ def main():
         try:
             reader = geoip2.database.Reader(args.geoip_db)
         except Exception:
+            print("GeoIP database not found \u2013 country information disabled.")
             reader = None
+    else:
+        print("GeoIP database not found \u2013 country information disabled.")
 
     conns = get_external_connections()
     results = []

--- a/lan_security_check.py
+++ b/lan_security_check.py
@@ -159,7 +159,10 @@ def check_external_comm(geoip_db: str = "GeoLite2-Country.mmdb") -> Dict[str, An
         try:
             reader = geoip2.database.Reader(geoip_db)
         except Exception:
+            print("GeoIP database not found \u2013 country information disabled.")
             reader = None
+    else:
+        print("GeoIP database not found \u2013 country information disabled.")
     suspicious = []
     country_counts: Dict[str, int] = {}
     for ip, _ in conns:


### PR DESCRIPTION
## Summary
- warn when GeoIP database is missing in `external_ip_report.py`
- warn when GeoIP database is missing in `lan_security_check.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874901faf248323bc59f99ca06f1964