### PR TITLE
Add scanner requirement check before network scan

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,10 +82,46 @@ class _HomePageState extends State<HomePage> {
       buffer.writeln();
     }
 
+    const installCmds = '''
+# Debian/Ubuntu
+sudo apt install nmap arp-scan speedtest-cli graphviz wkhtmltopdf
+
+# Fedora
+sudo dnf install nmap arp-scan speedtest-cli graphviz wkhtmltopdf
+
+# macOS (Homebrew)
+brew install nmap arp-scan speedtest-cli graphviz wkhtmltopdf
+
+# Windows
+winget install -e --id Nmap.Nmap      # nmap
+winget install -e --id Graphviz.Graphviz  # graphviz
+winget install -e --id wkhtmltopdf.wkhtmltopdf  # wkhtmltopdf
+pip install speedtest-cli
+# arp-scan は Windows 版が存在しないため省略
+''';
+
     final devices = await net.scanNetwork(onError: (msg) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('LANスキャン失敗: $msg')));
+        if (msg.startsWith('Missing scanners:')) {
+          showDialog(
+            context: context,
+            builder: (_) => AlertDialog(
+              title: const Text('必要なツールが見つかりません'),
+              content: SingleChildScrollView(
+                child: SelectableText('$msg\n\n$installCmds'),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text('LANスキャン失敗: $msg')));
+        }
       }
     });
     setState(() {

--- a/scanner_check.py
+++ b/scanner_check.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Check availability of network scanning tools."""
+import json
+import shutil
+import sys
+from typing import List
+
+TOOLS = ["arp-scan", "nmap"]
+
+def check_missing_tools() -> List[str]:
+    """Return list of missing tools from TOOLS."""
+    return [t for t in TOOLS if shutil.which(t) is None]
+
+
+def main() -> None:
+    missing = check_missing_tools()
+    print(json.dumps({"missing": missing}, ensure_ascii=False))
+    sys.exit(0 if not missing else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_scanner_check.py
+++ b/test/test_scanner_check.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+import scanner_check
+
+class ScannerCheckTest(unittest.TestCase):
+    def test_missing_tools(self):
+        with patch('scanner_check.shutil.which', return_value=None):
+            missing = scanner_check.check_missing_tools()
+            self.assertEqual(set(missing), {'arp-scan', 'nmap'})
+
+def load_tests(loader, tests, pattern):
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(ScannerCheckTest))
+    return suite
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure required scanners are present before running LAN discovery
- prompt user with install instructions when scanners are missing
- expose command list from README in the dialog
- new Python helper `scanner_check.py`
- tests for scanner check logic

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687499c478c08323b37d71204d667352