### PR TITLE
Fix RiskItem import

### DIFF
--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import '../diagnostics.dart' show SecurityReport;
+import '../diagnostics.dart' show SecurityReport, RiskItem;
 import '../extended_results.dart' show LanDeviceRisk;
 import 'python_utils.dart';
 import 'file_utils.dart';


### PR DESCRIPTION
## Summary
- import `RiskItem` so `loadHistoryReports` builds

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a231a0e08323975aca3b270bfe9c