### PR TITLE
Fix RiskItem import for history reports

### DIFF
--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import '../diagnostics.dart' show SecurityReport;
+import '../diagnostics.dart' show SecurityReport, RiskItem;
 import '../extended_results.dart' show LanDeviceRisk;
 import 'python_utils.dart';
 import 'file_utils.dart';


### PR DESCRIPTION
## Summary
- fix missing `RiskItem` import in `report_utils.dart`

## Testing
- `pytest -q`
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a202a4988323830463f7dde8bc8d