### PR TITLE
Fix unused imports in tests

### DIFF
--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/main.dart';
 
 void main() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,7 +6,6 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 
 import 'package:nwc_densetsu/main.dart';
 


### PR DESCRIPTION
## Summary
- remove stray Material imports in widget tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a4a2ece883238400beacbdafef4a