### PR TITLE
Fix unused import in HistoryPage

### DIFF
--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -3,9 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 
-// Import using the package URI to ensure the same library instance is used
-// across the project.
-import 'package:nwc_densetsu/diagnostics.dart';
 import 'utils/report_utils.dart' as report_utils;
 import 'result_page.dart';
 


### PR DESCRIPTION
## Summary
- remove unused diagnostics import from `HistoryPage`

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b0a36e088323b3daaac810d4bfa8