### PR TITLE
Fix lint: remove unused flutter_svg import

### DIFF
--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
 import 'package:nwc_densetsu/result_page.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nwc_densetsu/extended_results.dart';
 import 'package:nwc_densetsu/utils/report_utils.dart' as report_utils;
 


### PR DESCRIPTION
## Summary
- fix dart analyzer warning by removing unused `flutter_svg` import from `test/result_page_test.dart`

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b07f84f08323bfd7ea78717de03a