### PR TITLE
Fix missing DeviceListPage to resolve analyzer error

### DIFF
--- a/lib/device_list_page.dart
+++ b/lib/device_list_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// A simple page that lists device IP addresses.
+class DeviceListPage extends StatelessWidget {
+  /// Devices to display.
+  final List<String> devices;
+
+  const DeviceListPage({super.key, this.devices = const []});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Devices')),
+      body: ListView(
+        children: [for (final d in devices) ListTile(title: Text(d))],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DeviceListPage` widget so the file is valid Dart code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b45a4b648323bee59e6fc55e5a0c