### PR TITLE
Improve header visibility for domain auth

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -439,7 +439,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('ドメインの送信元検証設定'),
+          const Text(
+            'ドメインの送信元検証設定',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('ドメイン')),


### PR DESCRIPTION
## Summary
- enlarge and bold the "ドメインの送信元検証設定" header on the diagnostic result page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fb1d82088323ae64edbd5c113244