### PR TITLE
Improve LAN devices heading style

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -507,7 +507,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('LAN内デバイス一覧とリスクチェック'),
+          const Text(
+            'LAN内デバイス一覧とリスクチェック',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         Row(
           children: [


### PR DESCRIPTION
## Summary
- increase the font size and make the text bold for the *LAN内デバイス一覧とリスクチェック* heading

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fb3df17c832396afb865319740e4