### PR TITLE
Improve defense section header

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -603,7 +603,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('端末の防御機能の有効性チェック'),
+          const Text(
+            '端末の防御機能の有効性チェック',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('保護機能')),


### PR DESCRIPTION
## Summary
- emphasize the "端末の防御機能の有効性チェック" header on the diagnostic results page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fb5bede08323bc032bcef3451c93