### PR TITLE
Improve visibility of GeoIP section title

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -470,7 +470,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('GeoIP解析：通信先の国別リスクチェック'),
+          const Text(
+            'GeoIP解析：通信先の国別リスクチェック',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('国名')),


### PR DESCRIPTION
## Summary
- emphasize GeoIP解析 section header

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fb2eae8c83238fcd73521c00d82c