### PR TITLE
Improve heading style

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -574,7 +574,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('外部通信の暗号化状況'),
+          const Text(
+            '外部通信の暗号化状況',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('宛先ドメイン')),


### PR DESCRIPTION
## Summary
- improve visibility of the external communication encryption section heading

## Testing
- `flutter test` *(fails: Home page shows title and buttons)*
- `pytest -q` *(fails: missing module 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6874fb4f44e483239768b16c136a2fba