### PR TITLE
Improve SSL section title styling

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -405,7 +405,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('SSL証明書の安全性チェック'),
+          const Text(
+            'SSL証明書の安全性チェック',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+          ),
         const SizedBox(height: 4),
         const Text('証明書の有効期限切れ'),
         const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- enhance the SSL certificate check section title for better visibility

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fa2120cc832390c3cc88905749b4