### PR TITLE
Implement Windows version detection for LAN devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ python lan_port_scan.py --subnet 192.168.1.0/24 --ports 22,80 --service --os
     "ip": "192.168.1.10",
     "mac": "AA:BB:CC:DD:EE:FF",
     "vendor": "Acme",
+    "os": "Microsoft Windows 10",
     "ports": [
       {"port": "22", "state": "open", "service": "ssh"}
     ]

--- a/lan_port_scan.py
+++ b/lan_port_scan.py
@@ -52,7 +52,8 @@ def scan_hosts(
                 "ip": h.get("ip", ""),
                 "mac": h.get("mac", ""),
                 "vendor": h.get("vendor", ""),
-                "ports": scanned,
+                "os": scanned.get("os", ""),
+                "ports": scanned.get("ports", []),
             })
     return results
 

--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -27,8 +27,9 @@ class PortStatus {
 class PortScanSummary {
   final String host;
   final List<PortStatus> results;
+  final String os;
 
-  const PortScanSummary(this.host, this.results);
+  const PortScanSummary(this.host, this.results, [this.os = '']);
 
   bool get hasOpen =>
       results.any((r) => r.state.toLowerCase() == 'open');
@@ -177,7 +178,8 @@ Future<PortScanSummary> scanPorts(String host,
             item['service'] ?? ''));
       }
     }
-    return PortScanSummary(host, portList);
+    final os = data['os']?.toString() ?? '';
+    return PortScanSummary(host, portList, os);
   } catch (e) {
     if (onError != null) onError('Failed to run $script: $e');
     return PortScanSummary(host, []);

--- a/lib/extended_results.dart
+++ b/lib/extended_results.dart
@@ -42,6 +42,7 @@ class LanDeviceRisk {
   final String ip;
   final String mac;
   final String vendor;
+  final String os;
   final String name;
   final String status;
   final String comment;
@@ -50,6 +51,7 @@ class LanDeviceRisk {
       {required this.ip,
       required this.mac,
       required this.vendor,
+      this.os = '',
       required this.name,
       required this.status,
       required this.comment});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -295,13 +295,15 @@ pip install speedtest-cli
 
     final lanDevices = <LanDeviceRisk>[];
     for (final dev in _devices) {
-      final summary = _scanResults.firstWhere((s) => s.host == dev.ip,
+      final summary = _scanResults.firstWhere(
+          (s) => s.host == dev.ip,
           orElse: () => const diag.PortScanSummary('', []));
       final open = [for (final p in summary.results) if (p.state == 'open') p.port];
       lanDevices.add(LanDeviceRisk(
         ip: dev.ip,
         mac: dev.mac,
         vendor: dev.vendor,
+        os: summary.os,
         name: dev.vendor,
         status: open.isEmpty ? 'ok' : 'warning',
         comment: open.isEmpty ? '' : 'open: ${open.join(',')}',

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -105,6 +105,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       ip: d.ip,
       mac: d.mac,
       vendor: d.vendor,
+      os: d.os,
       name: name,
       status: d.status,
       comment: d.comment,
@@ -536,6 +537,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
           DataColumn(label: Text('IPアドレス')),
           DataColumn(label: Text('MACアドレス')),
           DataColumn(label: Text('ベンダー名')),
+          DataColumn(label: Text('OS')),
           DataColumn(label: Text('機器名')),
           DataColumn(label: Text('状態')),
           DataColumn(label: Text('コメント')),
@@ -547,6 +549,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
               DataCell(Text(d.ip)),
               DataCell(Text(d.mac)),
               DataCell(Text(d.vendor)),
+              DataCell(Text(d.os)),
               DataCell(
                 TextField(
                   controller: _nameControllers[d.ip],

--- a/port_scan.py
+++ b/port_scan.py
@@ -37,6 +37,7 @@ def run_scan(
         raise RuntimeError(proc.stderr.strip())
     root = ET.fromstring(proc.stdout)
     results = []
+    os_name = ""
     for port in root.findall('.//port'):
         portid = port.get('portid')
         state_elem = port.find('state')
@@ -53,7 +54,11 @@ def run_scan(
                     [s for s in [product, version, extrainfo] if s]
                 ).strip()
         results.append(item)
-    return results
+    if os_detect:
+        m = root.find('.//osmatch')
+        if m is not None:
+            os_name = m.get('name', '')
+    return {"os": os_name, "ports": results}
 
 
 def main():
@@ -80,7 +85,7 @@ def main():
             os_detect=args.os,
             scripts=scripts,
         )
-        print(json.dumps({'host': args.host, 'ports': res}))
+        print(json.dumps({'host': args.host, 'os': res['os'], 'ports': res['ports']}))
     except Exception as e:
         print(json.dumps({'error': str(e)}))
         sys.exit(1)

--- a/test/test_lan_port_scan.py
+++ b/test/test_lan_port_scan.py
@@ -8,19 +8,20 @@ class LanPortScanJsonTest(unittest.TestCase):
     @patch('lan_port_scan._run_nmap_scan')
     def test_basic_json(self, mock_nmap, mock_scan):
         mock_nmap.return_value = [{'ip': '192.168.1.2', 'mac': 'aa', 'vendor': 'X'}]
-        mock_scan.return_value = [{'port': '22', 'state': 'open', 'service': 'ssh'}]
+        mock_scan.return_value = {'os': 'Windows', 'ports': [{'port': '22', 'state': 'open', 'service': 'ssh'}]}
         res = lan_port_scan.scan_hosts('192.168.1.0/24', ['22'])
         self.assertIsInstance(res, list)
         self.assertEqual(res[0]['ip'], '192.168.1.2')
         self.assertIn('ports', res[0])
         self.assertEqual(res[0]['ports'][0]['port'], '22')
+        self.assertEqual(res[0]['os'], 'Windows')
 
     @patch('lan_port_scan.run_scan')
     @patch('lan_port_scan._lookup_vendor', return_value='')
     @patch('lan_port_scan._run_nmap_scan')
     def test_fallback_nmap(self, mock_nmap, mock_lookup, mock_scan):
         mock_nmap.return_value = [{'ip': '10.0.0.5', 'mac': '', 'vendor': ''}]
-        mock_scan.return_value = []
+        mock_scan.return_value = {'os': '', 'ports': []}
         res = lan_port_scan.scan_hosts('10.0.0.0/24', ['80'])
         self.assertEqual(res[0]['ip'], '10.0.0.5')
         self.assertEqual(res[0]['ports'], [])
@@ -29,7 +30,7 @@ class LanPortScanJsonTest(unittest.TestCase):
 @patch('lan_port_scan._run_nmap_scan')
 def test_ipv6_hosts(mock_nmap, mock_scan):
     mock_nmap.return_value = [{'ip': 'fe80::1', 'mac': 'aa', 'vendor': 'X'}]
-    mock_scan.return_value = []
+    mock_scan.return_value = {'os': '', 'ports': []}
     res = lan_port_scan.scan_hosts('fe80::/64', ['80'])
     mock_scan.assert_called_with(
         'fe80::1', ['80'], service=False, os_detect=False, scripts=None
@@ -78,7 +79,7 @@ class LanPortScanConcurrencyTest(unittest.TestCase):
 
         def side_effect(*args, **kwargs):
             call_counts.append(len(FakeExecutor.instance.submitted))
-            return []
+            return {"os": "", "ports": []}
 
         with patch('lan_port_scan.run_scan', side_effect=side_effect) as mock_run:
             lan_port_scan.scan_hosts('1.1.1.0/24', ['80'])


### PR DESCRIPTION
## Summary
- extend port_scan to parse OS detection results
- expose OS details in lan_port_scan output and Flutter UI
- show OS column in diagnostic results
- document OS info in README
- update Python unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fcbb287483238e0f9c3ae92bafa9