### PR TITLE
Update scan_hosts to use as_completed

### DIFF
--- a/lan_port_scan.py
+++ b/lan_port_scan.py
@@ -5,7 +5,7 @@ import json
 
 from discover_hosts import _get_subnet, _run_nmap_scan, _lookup_vendor
 from port_scan import run_scan
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 DEFAULT_PORTS = [
     "21", "22", "23", "25", "53", "80", "110", "143",
@@ -33,20 +33,21 @@ def scan_hosts(
     results = []
     # Limit worker count to avoid exhausting system resources
     max_workers = min(32, max(1, len(hosts)))
-    futures = []
+    future_to_host = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for h in hosts:
-            futures.append(
-                executor.submit(
-                    run_scan,
-                    h["ip"],
-                    ports,
-                    service=service,
-                    os_detect=os_detect,
-                    scripts=scripts,
-                )
+            future = executor.submit(
+                run_scan,
+                h["ip"],
+                ports,
+                service=service,
+                os_detect=os_detect,
+                scripts=scripts,
             )
-        for h, fut in zip(hosts, futures):
+            future_to_host[future] = h
+
+        for fut in as_completed(future_to_host):
+            h = future_to_host[fut]
             scanned = fut.result()
             results.append({
                 "ip": h.get("ip", ""),

--- a/test/test_lan_port_scan.py
+++ b/test/test_lan_port_scan.py
@@ -65,7 +65,13 @@ class FakeExecutor:
         return FakeFuture(fn, *args, **kwargs)
 
 
+def _fake_as_completed(fs):
+    for f in fs:
+        yield f
+
+
 class LanPortScanConcurrencyTest(unittest.TestCase):
+    @patch('lan_port_scan.as_completed', _fake_as_completed)
     @patch('lan_port_scan.ThreadPoolExecutor', FakeExecutor)
     @patch('lan_port_scan.gather_hosts')
     def test_concurrent_execution(self, mock_gather):


### PR DESCRIPTION
## Summary
- use `as_completed` to gather port scan results in `lan_port_scan.scan_hosts`
- adjust concurrency test to patch `as_completed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fe087e188323bbc95118cb3337b9