### PR TITLE
Handle invalid SSL certs

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -246,8 +246,12 @@ Future<List<LanPortDevice>> scanLanWithPorts({
 /// Fetches SSL certificate information from the host.
 Future<SslResult> checkSslCertificate(String host) async {
   try {
-    final socket = await SecureSocket.connect(host, 443,
-        timeout: const Duration(seconds: 5));
+    final socket = await SecureSocket.connect(
+      host,
+      443,
+      timeout: const Duration(seconds: 5),
+      onBadCertificate: (_) => true,
+    );
     final cert = socket.peerCertificate;
     socket.destroy();
     if (cert == null) {


### PR DESCRIPTION
## Summary
- allow `checkSslCertificate` to inspect invalid certs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd7f553883239cfda462832e9d83