### PR TITLE
Add back button for history tab

### DIFF
--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -56,9 +56,21 @@ class _HistoryPageState extends State<HistoryPage> {
     return RefreshIndicator(
       onRefresh: _loadFiles,
       child: ListView.builder(
-        itemCount: _files.length,
+        itemCount: _files.length + 1,
         itemBuilder: (context, index) {
-          final f = _files[index];
+          if (index == 0) {
+            return Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () {
+                  DefaultTabController.of(context)?.animateTo(0);
+                },
+                icon: const Icon(Icons.arrow_back),
+                label: const Text('ホームに戻る'),
+              ),
+            );
+          }
+          final f = _files[index - 1];
           final name = p.basename(f.path);
           return ListTile(
             title: Text(name),


### PR DESCRIPTION
## Summary
- add a back button at the top of the history tab so users can return to the home tab

## Testing
- `pytest -q`
- `flutter test` *(fails: TestFailure expected one matching candidate, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_687503d32e588323ae99c37217a4ded3