### PR TITLE
Show explanation for external communication section

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -594,6 +594,14 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
             style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
         const SizedBox(height: 4),
+        const Text(
+          '宛先ドメインや通信プロトコルと、その通信が暗号化されているかを一覧表示します。',
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          '暗号化されていない通信では内容を傍受・改ざんされるリスクがあります。',
+        ),
+        const SizedBox(height: 4),
         DataTable(columns: const [
           DataColumn(label: Text('宛先ドメイン')),
           DataColumn(label: Text('通信プロトコル')),


### PR DESCRIPTION
## Summary
- add description of external communication encryption details and risks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875059925e48323a023030a9b1c0cfd