### PR TITLE
Add description to domain auth section

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -448,6 +448,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
             style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
         const SizedBox(height: 4),
+        const Text(
+          'SPF/DKIM/DMARC の設定状況を取得し、未設定のドメインはなりすましメール送信に悪用される恐れがあります。',
+        ),
+        const SizedBox(height: 8),
         DataTable(columns: const [
           DataColumn(label: Text('ドメイン')),
           DataColumn(label: Text('SPF')),


### PR DESCRIPTION
## Summary
- show explanatory text under the "ドメインの送信元検証設定" heading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750562d7948323884e22ca3d5d7300