### PR TITLE
Add defense section description

### DIFF
--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -626,6 +626,10 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
             style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
         const SizedBox(height: 4),
+        const Text(
+          'セキュリティソフトやファイアウォールなど端末に備わる防御機能が有効か確認します。無効の場合、不正侵入やマルウェア感染のリスクが高まります。',
+        ),
+        const SizedBox(height: 8),
         DataTable(columns: const [
           DataColumn(label: Text('保護機能')),
           DataColumn(label: Text('状態')),

--- a/test/open_result_page_test.dart
+++ b/test/open_result_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/diagnostics.dart';
+import 'package:nwc_densetsu/extended_results.dart';
 
 void main() {
   testWidgets('port summaries shown when result page opened', (tester) async {
@@ -21,5 +22,27 @@ void main() {
     expect(find.textContaining('80'), findsOneWidget);
     expect(find.text('http'), findsOneWidget);
     expect(find.text('1/1 ポート開放'), findsOneWidget);
+  });
+
+  testWidgets('defense section shows description', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DiagnosticResultPage(
+          securityScore: 0,
+          items: [],
+          portSummaries: [],
+          defenseStatus: [
+            DefenseFeatureStatus(feature: 'AV', status: 'ok', comment: '')
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('端末の防御機能の有効性チェック'), findsOneWidget);
+    expect(
+      find.text(
+          'セキュリティソフトやファイアウォールなど端末に備わる防御機能が有効か確認します。無効の場合、不正侵入やマルウェア感染のリスクが高まります。'),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- show explanatory text in the "端末の防御機能の有効性チェック" section
- verify the text in widget test

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687505a335ec8323948a2ed166f914f4