### PR TITLE
Show remote Windows version

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -149,14 +149,20 @@ Future<String?> getWindowsVersion({void Function(String message)? onError}) asyn
 }
 
 /// Runs the bundled Python script using `nmap` to scan [ports] on [host].
+/// When [osDetect] is true, OS detection (`-O`) is enabled.
 /// Returns a [PortScanSummary] containing all results.
 Future<PortScanSummary> scanPorts(String host,
-    {List<int>? ports, void Function(String message)? onError}) async {
+    {List<int>? ports,
+    bool osDetect = false,
+    void Function(String message)? onError}) async {
   const script = 'port_scan.py';
   try {
     final args = <String>[script, host];
     if (ports != null && ports.isNotEmpty) {
       args.add(ports.join(','));
+    }
+    if (osDetect) {
+      args.add('--os');
     }
     final result = await Process.run(pythonExecutable, args);
     if (result.exitCode != 0) {

--- a/lib/extended_results.dart
+++ b/lib/extended_results.dart
@@ -46,6 +46,7 @@ class LanDeviceRisk {
   final String name;
   final String status;
   final String comment;
+  final String note;
 
   const LanDeviceRisk(
       {required this.ip,
@@ -54,7 +55,8 @@ class LanDeviceRisk {
       this.os = '',
       required this.name,
       required this.status,
-      required this.comment});
+      required this.comment,
+      this.note = ''});
 }
 
 class ExternalCommInfo {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,7 +155,7 @@ pip install speedtest-cli
       buffer.writeln(pingRes);
 
       final portFuture = diag
-          .scanPorts(ip, onError: (msg) {
+          .scanPorts(ip, osDetect: true, onError: (msg) {
         if (mounted) {
           ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(content: Text('ポートスキャン失敗: $msg')));
@@ -299,6 +299,7 @@ pip install speedtest-cli
           (s) => s.host == dev.ip,
           orElse: () => const diag.PortScanSummary('', []));
       final open = [for (final p in summary.results) if (p.state == 'open') p.port];
+      final note = summary.os.contains('Windows') ? summary.os : '';
       lanDevices.add(LanDeviceRisk(
         ip: dev.ip,
         mac: dev.mac,
@@ -307,6 +308,7 @@ pip install speedtest-cli
         name: dev.vendor,
         status: open.isEmpty ? 'ok' : 'warning',
         comment: open.isEmpty ? '' : 'open: ${open.join(',')}',
+        note: note,
       ));
     }
 

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -109,6 +109,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
       name: name,
       status: d.status,
       comment: d.comment,
+      note: d.note,
     );
     _applyFilter();
   }
@@ -567,6 +568,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
           DataColumn(label: Text('機器名')),
           DataColumn(label: Text('状態')),
           DataColumn(label: Text('コメント')),
+          DataColumn(label: Text('備考')),
         ], rows: [
           for (final d in _filteredDevices)
             DataRow(
@@ -589,6 +591,7 @@ class _DiagnosticResultPageState extends State<DiagnosticResultPage> {
               ),
               DataCell(Text(d.status)),
               DataCell(Text(d.comment)),
+              DataCell(Text(d.note)),
               ],
             ),
         ]),

--- a/test/diagnostic_result_page_test.dart
+++ b/test/diagnostic_result_page_test.dart
@@ -80,7 +80,8 @@ void main() {
           vendor: 'Acme',
           name: 'Dev',
           status: 'ok',
-          comment: '')
+          comment: '',
+          note: '')
     ];
     const comms = [
       ExternalCommInfo(
@@ -136,21 +137,24 @@ void main() {
           vendor: 'A',
           name: 'D1',
           status: 'warning',
-          comment: ''),
+          comment: '',
+          note: ''),
       LanDeviceRisk(
           ip: '1.1.1.2',
           mac: '00:22',
           vendor: 'B',
           name: 'D2',
           status: 'danger',
-          comment: ''),
+          comment: '',
+          note: ''),
       LanDeviceRisk(
           ip: '1.1.1.3',
           mac: '00:33',
           vendor: 'C',
           name: 'D3',
           status: 'safe',
-          comment: ''),
+          comment: '',
+          note: ''),
     ];
 
     await tester.pumpWidget(
@@ -187,28 +191,32 @@ void main() {
           vendor: 'v',
           name: 'n1',
           status: 'safe',
-          comment: ''),
+          comment: '',
+          note: ''),
       LanDeviceRisk(
           ip: '2',
           mac: 'm2',
           vendor: 'v',
           name: 'n2',
           status: 'warning',
-          comment: ''),
+          comment: '',
+          note: ''),
       LanDeviceRisk(
           ip: '3',
           mac: 'm3',
           vendor: 'v',
           name: 'n3',
           status: 'danger',
-          comment: ''),
+          comment: '',
+          note: ''),
       LanDeviceRisk(
           ip: '4',
           mac: 'm4',
           vendor: 'v',
           name: 'n4',
           status: 'danger',
-          comment: ''),
+          comment: '',
+          note: ''),
     ];
 
     await tester.pumpWidget(

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -64,7 +64,8 @@ void main() {
           vendor: 'Test',
           name: 'd',
           status: 'ok',
-          comment: '')
+          comment: '',
+          note: '')
     ];
 
     var called = false;
@@ -98,7 +99,8 @@ void main() {
           vendor: 'Test',
           name: 'd',
           status: 'ok',
-          comment: '')
+          comment: '',
+          note: '')
     ];
 
     var called = false;


### PR DESCRIPTION
## Summary
- add a `note` field to `LanDeviceRisk` to hold Windows version notes
- support OS detection in `scanPorts` and enable it from LAN scans
- include Windows version in LAN device list
- show new `備考` column in the results table
- update tests

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687504e2652c8323bf1445ec2a35afbc