### PR TITLE
Fix utmActive constructor parameter

### DIFF
--- a/lib/diagnostics.dart
+++ b/lib/diagnostics.dart
@@ -71,8 +71,9 @@ class SecurityReport {
 
   /// Create a new [SecurityReport].
   ///
-  /// The [openPorts], [geoip] and [utmActive] parameters are optional and will
-  /// default to empty values when omitted.
+  /// The [openPorts] and [geoip] parameters are optional and will default to
+  /// empty values when omitted. The [utmActive] flag must be explicitly
+  /// provided.
   const SecurityReport(
     this.ip,
     this.score,
@@ -81,7 +82,7 @@ class SecurityReport {
     this.path, {
     this.openPorts = const [],
     this.geoip = '',
-    bool utmActive = false,
+    required bool utmActive,
   }) : _utmActive = utmActive;
 }
 

--- a/test/result_page_test.dart
+++ b/test/result_page_test.dart
@@ -9,9 +9,9 @@ void main() {
   testWidgets('ResultPage displays scores and items', (WidgetTester tester) async {
     const reports = [
       SecurityReport('1.1.1.1', 9, [RiskItem('risk1', 'fix1')], [], '',
-          openPorts: [80], geoip: 'US'),
+          openPorts: [80], geoip: 'US', utmActive: false),
       SecurityReport('2.2.2.2', 4, [RiskItem('risk2', 'fix2')], [], '',
-          openPorts: [22], geoip: 'JP'),
+          openPorts: [22], geoip: 'JP', utmActive: false),
     ];
 
     await tester.pumpWidget(

--- a/test/score_chart_test.dart
+++ b/test/score_chart_test.dart
@@ -7,9 +7,9 @@ void main() {
   testWidgets('ScoreChart renders', (WidgetTester tester) async {
     const reports = [
       const SecurityReport('1.1.1.1', 9.0, <RiskItem>[], [], '',
-          openPorts: [80], geoip: 'US'),
+          openPorts: [80], geoip: 'US', utmActive: false),
       const SecurityReport('2.2.2.2', 3.0, <RiskItem>[], [], '',
-          openPorts: [22], geoip: 'JP'),
+          openPorts: [22], geoip: 'JP', utmActive: false),
     ];
     await tester.pumpWidget(
       MaterialApp(home: Scaffold(body: ScoreChart(reports: reports))),


### PR DESCRIPTION
## Summary
- make `utmActive` mandatory in `SecurityReport`
- update helpers and tests to always pass `utmActive`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759e1ce45083238e2bae2679b3ddb7