### PR TITLE
Fix tests for new utmActive parameter

### DIFF
--- a/test/run_security_report_json_score_test.dart
+++ b/test/run_security_report_json_score_test.dart
@@ -24,6 +24,7 @@ void main() {
       openPorts: const [],
       sslValid: true,
       spfValid: true,
+      utmActive: false,
       processRunner: fakeRunner,
     );
 


### PR DESCRIPTION
## Summary
- adjust tests for `utmActive` being a required argument

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6875a3022efc832387fdf7da2c7a0f25