### PR TITLE
Unify report generation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,13 @@ python security_report.py 192.168.1.10 80,443 valid true JP true
 
 `generate_html_report.py` を使うと、デバイス情報から HTML 形式のレポートを作成できます。
 `--pdf` オプションを指定すると、`pdfkit` または `weasyprint` が利用可能な環境では PDF も生成します。
+`--csv` を指定すると同時に CSV 形式のレポートも出力します。
 PDF 出力には `wkhtmltopdf` (pdfkit) もしくは `weasyprint` をインストールしておく必要があります。
 
 実行例:
 
 ```bash
-python generate_html_report.py devices.json -o report.html --pdf
+python generate_html_report.py devices.json -o report.html --pdf --csv report.csv
 ```
 
 入力 JSON の例:
@@ -353,7 +354,7 @@ flutter test
 - `lan_port_scan.py`
 - `network_speed.py`
 - `security_report.py`
-- `generate_html_report.py`
+- `generate_html_report.py` (CSV 出力も可能)
 - `generate_topology.py`
 
 ### 配布手順例

--- a/generate_csv_report.py
+++ b/generate_csv_report.py
@@ -1,39 +1,15 @@
 #!/usr/bin/env python3
-"""Generate CSV report from scan data with security scores and UTM recommendations."""
+"""Generate CSV report from scan data.
+
+This wrapper calls into :mod:`generate_html_report` for the actual
+implementation and is kept for backward compatibility.
+"""
+from __future__ import annotations
+
 import argparse
 import json
-import csv
-from typing import List, Dict
 
-from security_score import calc_security_score
-from report_utils import calc_utm_items
-
-
-def generate_report(devices: List[Dict]) -> List[List[str]]:
-    rows = []
-    for dev in devices:
-        name = dev.get("device") or dev.get("ip") or "unknown"
-        ports = [str(p) for p in dev.get("open_ports", [])]
-        countries = [c.upper() for c in dev.get("countries", [])]
-        danger_list = [p for p in ports if p in {"3389", "445", "23"}]
-        data = {
-            "danger_ports": danger_list,
-            "geoip": countries[0] if countries else "",
-            "open_port_count": len(ports),
-            "ssl": dev.get("ssl", "valid"),
-            "dns_fail_rate": 0.0,
-        }
-        res = calc_security_score(data)
-        score = res["score"]
-        utm = calc_utm_items(score, ports, countries)
-        rows.append([
-            name,
-            str(score),
-            ",".join(ports),
-            ",".join(countries),
-            ",".join(utm),
-        ])
-    return rows
+from generate_html_report import save_csv_report, _extract_devices
 
 
 def main() -> None:
@@ -43,14 +19,9 @@ def main() -> None:
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as f:
-        devices = json.load(f)
+        data = json.load(f)
 
-    rows = generate_report(devices)
-    header = ["device", "score", "open_ports", "countries", "utm_items"]
-    with open(args.output, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(header)
-        writer.writerows(rows)
+    save_csv_report(_extract_devices(data), args.output)
     print(f"Report written to {args.output}")
 
 


### PR DESCRIPTION
## Summary
- support `--csv` in `generate_html_report.py`
- delegate `generate_csv_report.py` to `generate_html_report.py`
- document new CSV option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f8d2259483239c24bcb89c0eab22