### PR TITLE
Fix const lists in ScoreChart test

### DIFF
--- a/test/score_chart_test.dart
+++ b/test/score_chart_test.dart
@@ -6,10 +6,10 @@ import 'package:nwc_densetsu/diagnostics.dart';
 void main() {
   testWidgets('ScoreChart renders', (WidgetTester tester) async {
     const reports = [
-      const SecurityReport('1.1.1.1', 9.0, <RiskItem>[], [], '',
-          openPorts: [80], geoip: 'US', utmActive: false),
-      const SecurityReport('2.2.2.2', 3.0, <RiskItem>[], [], '',
-          openPorts: [22], geoip: 'JP', utmActive: false),
+      const SecurityReport('1.1.1.1', 9.0, const <RiskItem>[], const <String>[], '',
+          openPorts: const [80], geoip: 'US', utmActive: false),
+      const SecurityReport('2.2.2.2', 3.0, const <RiskItem>[], const <String>[], '',
+          openPorts: const [22], geoip: 'JP', utmActive: false),
     ];
     await tester.pumpWidget(
       MaterialApp(home: Scaffold(body: ScoreChart(reports: reports))),


### PR DESCRIPTION
## Summary
- update `score_chart_test.dart` to use const lists when creating `SecurityReport` objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687610886ea08323a1c8671bf1f58fc7