### PR TITLE
Implement stall detection for port scans

### DIFF
--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -1,53 +1,61 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import port_scan
 
 
 class PortScanScriptTest(unittest.TestCase):
     def test_run_scan_uses_all_ports_when_empty(self):
         xml = "<nmaprun></nmaprun>"
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
             res = port_scan.run_scan('1.1.1.1', [])
-            m.assert_called_with([
-                'nmap', '--script', 'vuln', '-p-', '-oX', '-', '1.1.1.1'
-            ], capture_output=True, text=True)
-            assert 'ports' in res
+            called_cmd = m.call_args[0][0]
+            self.assertEqual(
+                called_cmd,
+                ['nmap', '--script', 'vuln', '--stats-every', '5s', '-p-', '-oX', '-', '1.1.1.1']
+            )
+            self.assertIn('ports', res)
 
     def test_run_scan_with_options(self):
         xml = "<nmaprun></nmaprun>"
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
             res = port_scan.run_scan('1.1.1.1', [], service=True, os_detect=True, scripts=['vuln'])
-            m.assert_called_with([
-                'nmap', '-sV', '-O', '--script', 'vuln', '-p-', '-oX', '-', '1.1.1.1'
-            ], capture_output=True, text=True)
-            assert 'ports' in res
+            called_cmd = m.call_args[0][0]
+            self.assertEqual(
+                called_cmd,
+                ['nmap', '-sV', '-O', '--script', 'vuln', '--stats-every', '5s', '-p-', '-oX', '-', '1.1.1.1']
+            )
+            self.assertIn('ports', res)
 
     def test_run_scan_ipv6_adds_flag(self):
         xml = "<nmaprun></nmaprun>"
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
             res = port_scan.run_scan('fe80::1', [])
-            m.assert_called_with([
-                'nmap', '-6', '--script', 'vuln', '-p-', '-oX', '-', 'fe80::1'
-            ], capture_output=True, text=True)
-            assert 'ports' in res
+            called_cmd = m.call_args[0][0]
+            self.assertEqual(
+                called_cmd,
+                ['nmap', '-6', '--script', 'vuln', '--stats-every', '5s', '-p-', '-oX', '-', 'fe80::1']
+            )
+            self.assertIn('ports', res)
 
     def test_run_scan_custom_script_overrides_default(self):
         xml = "<nmaprun></nmaprun>"
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
             res = port_scan.run_scan('1.1.1.1', [], scripts=['http-enum'])
-            m.assert_called_with([
-                'nmap', '--script', 'http-enum', '-p-', '-oX', '-', '1.1.1.1'
-            ], capture_output=True, text=True)
-            assert 'ports' in res
+            called_cmd = m.call_args[0][0]
+            self.assertEqual(
+                called_cmd,
+                ['nmap', '--script', 'http-enum', '--stats-every', '5s', '-p-', '-oX', '-', '1.1.1.1']
+            )
+            self.assertIn('ports', res)
 
     def test_run_scan_parses_os(self):
         xml = "<nmaprun><host><os><osmatch name='Microsoft Windows 11' /></os></host></nmaprun>"
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
             res = port_scan.run_scan('1.1.1.1', [], os_detect=True)
             self.assertEqual(res['os'], 'Microsoft Windows 11')
 


### PR DESCRIPTION
## Summary
- detect stalled nmap scans by monitoring output
- update tests for new progress-aware execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760e806c08832396826c55301dc817