### PR TITLE
Temporarily disable scan history

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -222,7 +222,7 @@ pip install speedtest-cli
       _lanScanning = false;
       _devices = devices;
     });
-    if (mounted) {
+    if (mounted && path.isNotEmpty) {
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text('結果保存: $path')));
     }

--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -95,6 +95,11 @@ Future<String> generateTopologyDiagram([List<LanDeviceRisk> devices = const []])
 
 /// Saves [reports] to `history/YYYYMMDD_HHMM.json` and returns the file path.
 Future<String> saveHistoryReports(List<SecurityReport> reports) async {
+  // Allow disabling history saving via environment variable.
+  final disabled = Platform.environment['NWCD_DISABLE_HISTORY'];
+  if (disabled != null && disabled.toLowerCase() == 'true') {
+    return '';
+  }
   final historyDir = Directory(p.join(Directory.current.path, 'history'));
   await historyDir.create(recursive: true);
   final now = DateTime.now();

--- a/port_scan.py
+++ b/port_scan.py
@@ -12,7 +12,10 @@ def _exec_nmap(cmd: list[str], progress_timeout: float | None) -> str:
     """Run nmap command and return stdout. If progress_timeout is provided,
     terminate the process if no output is received within the timeout."""
     if progress_timeout is None:
-        proc = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=SCAN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("nmap scan timed out")
         if proc.returncode != 0:
             raise RuntimeError(proc.stderr.strip())
         return proc.stdout

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -1,4 +1,5 @@
 import unittest
+import subprocess
 from unittest.mock import patch
 import port_scan
 
@@ -63,7 +64,7 @@ class PortScanScriptTest(unittest.TestCase):
         with patch('subprocess.run') as m:
             m.side_effect = subprocess.TimeoutExpired(cmd='nmap', timeout=1)
             with self.assertRaises(RuntimeError):
-                port_scan.run_scan('1.1.1.1', [], timeout=1)
+                port_scan.run_scan('1.1.1.1', [], progress_timeout=None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add env flag to disable saving scan history
- show SnackBar only when history is saved
- handle nmap timeout in port_scan helper
- fix unit test for timeout path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f7b259348323a9970887afa0dd2c