### PR TITLE
Fix timeout parameter for LAN port scanning

### DIFF
--- a/lan_port_scan.py
+++ b/lan_port_scan.py
@@ -43,7 +43,7 @@ def scan_hosts(
                 service=service,
                 os_detect=os_detect,
                 scripts=scripts,
-                timeout=SCAN_TIMEOUT,
+                progress_timeout=SCAN_TIMEOUT,
             )
             future_to_host[future] = h
 

--- a/test/test_lan_port_scan.py
+++ b/test/test_lan_port_scan.py
@@ -38,7 +38,7 @@ def test_ipv6_hosts(mock_nmap, mock_scan):
         service=False,
         os_detect=False,
         scripts=None,
-        timeout=lan_port_scan.SCAN_TIMEOUT,
+        progress_timeout=lan_port_scan.SCAN_TIMEOUT,
     )
     assert res[0]['ip'] == 'fe80::1'
 


### PR DESCRIPTION
## Summary
- pass `progress_timeout` when running scans in `lan_port_scan`
- update LAN port scan tests to check the correct argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f7057b5c8323bbdb00cf3a3136b4