### PR TITLE
Add scan speed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ PDF 生成を行う場合は、`pdfkit` が利用する `wkhtmltopdf` または 
 ```bash
 python port_scan.py <host> [port_list] [--service] [--os] [--script vuln]
 ```
+`--timing` を指定すると `nmap` のタイミングテンプレート (`-T0`~`-T5`) を調整できます。
+`--fast` を指定すると `--timing` 未指定時に `-T4` が適用され、処理速度を向上させます。
 `--script` を省略した場合は `vuln` スクリプトが自動的に指定され、脆弱性チェックが行われます。
 `nmap` 実行には 60 秒のタイムアウトを設けており、極端に時間がかかる場合は自動で終了します。
 
@@ -129,6 +131,8 @@ nmap -V
 ```bash
 python lan_port_scan.py --subnet 192.168.1.0/24 --ports 22,80 --service --os
 ```
+`--workers` オプションで同時スキャン数を指定すると、環境に合わせて処理速度を調整できます。
+`--timing` で `nmap` のタイミングを指定できます。`--fast` を付けると `--timing` 未指定時に `-T4` が適用され、並列数も自動設定されます。
 
 出力例:
 

--- a/lan_port_scan.py
+++ b/lan_port_scan.py
@@ -28,11 +28,17 @@ def scan_hosts(
     service: bool = False,
     os_detect: bool = False,
     scripts: list[str] | None = None,
+    max_workers: int | None = None,
+    timing: int | None = None,
+    fast: bool = True,
 ):
     hosts = gather_hosts(subnet)
     results = []
     # Limit worker count to avoid exhausting system resources
-    max_workers = min(32, max(1, len(hosts)))
+    if max_workers is None:
+        max_workers = min(32, max(1, len(hosts))) if fast else 1
+    else:
+        max_workers = max(1, max_workers)
     future_to_host = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for h in hosts:
@@ -44,6 +50,8 @@ def scan_hosts(
                 os_detect=os_detect,
                 scripts=scripts,
                 progress_timeout=SCAN_TIMEOUT,
+                timing=timing,
+                fast=fast,
             )
             future_to_host[future] = h
 
@@ -67,6 +75,22 @@ def main():
     parser.add_argument("--service", action="store_true", help="Enable service version detection")
     parser.add_argument("--os", action="store_true", help="Enable OS detection")
     parser.add_argument("--script", help="Comma separated nmap scripts")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        help="Number of concurrent workers",
+    )
+    parser.add_argument(
+        "--timing",
+        type=int,
+        choices=range(0, 6),
+        help="nmap timing template (0-5)",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Enable speed optimizations (defaults to -T4 if --timing not set)",
+    )
     args = parser.parse_args()
 
     subnet = args.subnet or _get_subnet() or "192.168.1.0/24"
@@ -81,6 +105,9 @@ def main():
         service=args.service,
         os_detect=args.os,
         scripts=scripts,
+        max_workers=args.workers,
+        timing=args.timing,
+        fast=args.fast,
     )
     print(json.dumps(results, ensure_ascii=False))
 

--- a/test/test_port_scan.py
+++ b/test/test_port_scan.py
@@ -54,6 +54,22 @@ class PortScanScriptTest(unittest.TestCase):
             )
             self.assertIn('ports', res)
 
+    def test_run_scan_with_timing(self):
+        xml = "<nmaprun></nmaprun>"
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
+            port_scan.run_scan('1.1.1.1', [], timing=4)
+            called_cmd = m.call_args[0][0]
+            self.assertIn('-T4', called_cmd)
+
+    def test_run_scan_fast_defaults_timing(self):
+        xml = "<nmaprun></nmaprun>"
+        with patch('port_scan._exec_nmap') as m:
+            m.return_value = xml
+            port_scan.run_scan('1.1.1.1', [], fast=True)
+            called_cmd = m.call_args[0][0]
+            self.assertIn('-T4', called_cmd)
+
     def test_run_scan_parses_os(self):
         xml = "<nmaprun><host><os><osmatch name='Microsoft Windows 11' /></os></host></nmaprun>"
         with patch('port_scan._exec_nmap') as m:


### PR DESCRIPTION
## Summary
- tune `nmap` speed using `--timing` option
- allow adjusting concurrency with `--workers`
- document these new options
- test new timing feature
- add `--fast` toggle to quickly enable speed optimizations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68771fe03e9483239b68403003085b72