### PR TITLE
Add dynamic scan API and Flutter UI

### DIFF
--- a/lib/dynamic_scan_page.dart
+++ b/lib/dynamic_scan_page.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'dynamic_scan_service.dart';
+
+/// Page that displays dynamic scan results.
+class DynamicScanPage extends StatefulWidget {
+  const DynamicScanPage({super.key});
+
+  @override
+  State<DynamicScanPage> createState() => _DynamicScanPageState();
+}
+
+class _DynamicScanPageState extends State<DynamicScanPage> {
+  final DynamicScanService _service = DynamicScanService();
+  List<DynamicScanResult> _results = [];
+  bool _running = false;
+  Timer? _timer;
+  final Set<String> _alerted = <String>{};
+
+  Future<void> _start() async {
+    try {
+      await _service.startScan();
+      setState(() {
+        _running = true;
+        _results = [];
+        _alerted.clear();
+      });
+      _timer = Timer.periodic(const Duration(seconds: 2), (_) async {
+        final res = await _service.fetchResults();
+        if (!mounted) return;
+        setState(() => _results = res);
+        _checkAlerts(res);
+      });
+    } catch (e) {
+      _showError('開始失敗: $e');
+    }
+  }
+
+  Future<void> _stop() async {
+    try {
+      await _service.stopScan();
+      _timer?.cancel();
+      setState(() => _running = false);
+      _showMessage('スキャン停止');
+    } catch (e) {
+      _showError('停止失敗: $e');
+    }
+  }
+
+  void _checkAlerts(List<DynamicScanResult> res) {
+    for (final r in res) {
+      if (!_alerted.contains(r.ip) && r.ports.isNotEmpty) {
+        _alerted.add(r.ip);
+        _showMessage('オープンポート検出: ${r.ip}');
+      }
+    }
+  }
+
+  void _showMessage(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  void _showError(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(msg), backgroundColor: Colors.red));
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dynamic Scan')),
+      body: Column(
+        children: [
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: _running ? null : _start,
+                child: const Text('Start'),
+              ),
+              const SizedBox(width: 16),
+              ElevatedButton(
+                onPressed: _running ? _stop : null,
+                child: const Text('Stop'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: ListView(
+              children: [
+                for (final r in _results)
+                  ListTile(
+                    title: Text(r.ip),
+                    subtitle: Text(
+                        'Ports: ${r.ports.map((p) => p['port']).join(', ')}'),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/dynamic_scan_service.dart
+++ b/lib/dynamic_scan_service.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// Service class to interact with dynamic scan API.
+class DynamicScanService {
+  /// Base URL of the API server.
+  final String baseUrl;
+
+  DynamicScanService({this.baseUrl = 'http://localhost:8000'});
+
+  /// Start dynamic network scan.
+  Future<void> startScan({String? subnet}) async {
+    final res = await http.post(
+      Uri.parse('$baseUrl/dynamic-scan/start'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'subnet': subnet}),
+    );
+    if (res.statusCode != 200) {
+      throw Exception('Failed to start scan: ${res.body}');
+    }
+  }
+
+  /// Stop dynamic scan.
+  Future<void> stopScan() async {
+    final res = await http.post(Uri.parse('$baseUrl/dynamic-scan/stop'));
+    if (res.statusCode != 200) {
+      throw Exception('Failed to stop scan: ${res.body}');
+    }
+  }
+
+  /// Fetch current scan results.
+  Future<List<DynamicScanResult>> fetchResults() async {
+    final res = await http.get(Uri.parse('$baseUrl/dynamic-scan/results'));
+    if (res.statusCode != 200) {
+      throw Exception('Failed to fetch results: ${res.body}');
+    }
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    final list = data['results'] as List<dynamic>? ?? [];
+    return [for (final item in list) DynamicScanResult.fromJson(item)];
+  }
+}
+
+/// Represents a single dynamic scan result.
+class DynamicScanResult {
+  final String ip;
+  final List<dynamic> ports;
+
+  DynamicScanResult({required this.ip, required this.ports});
+
+  factory DynamicScanResult.fromJson(Map<String, dynamic> json) {
+    return DynamicScanResult(
+      ip: json['ip'] ?? '',
+      ports: json['ports'] as List<dynamic>? ?? [],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:nwc_densetsu/progress_list.dart';
 import 'package:nwc_densetsu/result_page.dart';
 import 'package:nwc_densetsu/extended_results.dart';
 import 'config.dart';
+import 'dynamic_scan_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -308,6 +309,20 @@ class _HomePageState extends State<HomePage> {
               child: ElevatedButton(
                 onPressed: _lanScanning ? null : _runLanScan,
                 child: const Text('LANスキャン'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Tooltip(
+              message: 'バックグラウンドで継続的にスキャンします',
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const DynamicScanPage(),
+                    ),
+                  );
+                },
+                child: const Text('ダイナミックスキャン'),
               ),
             ),
             if (_lanScanning) ...[

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ weasyprint==65.1
 webencodings==0.5.1
 yarl==1.20.1
 zopfli==0.2.3.post1
+fastapi==0.115.0
+uvicorn==0.30.1

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from threading import Event, Thread
+from typing import List, Dict, Any
+
+from lan_port_scan import scan_hosts, DEFAULT_PORTS
+from discover_hosts import _get_subnet
+
+app = FastAPI()
+
+_scan_thread: Thread | None = None
+_stop_event = Event()
+_scan_results: List[Dict[str, Any]] = []
+
+
+class ScanRequest(BaseModel):
+    subnet: str | None = None
+    ports: List[str] | None = None
+
+
+def _scan_loop(subnet: str, ports: List[str]) -> None:
+    global _scan_results
+    while not _stop_event.is_set():
+        _scan_results = scan_hosts(subnet, ports)
+        # wait a bit before next scan, allowing stop_event to terminate early
+        _stop_event.wait(5)
+
+
+@app.post("/dynamic-scan/start")
+def start_scan(req: ScanRequest) -> Dict[str, str]:
+    """Start dynamic scanning in background."""
+    global _scan_thread
+    if _scan_thread and _scan_thread.is_alive():
+        raise HTTPException(status_code=400, detail="scan already running")
+    subnet = req.subnet or _get_subnet() or "192.168.1.0/24"
+    ports = req.ports or DEFAULT_PORTS
+    _stop_event.clear()
+    _scan_thread = Thread(target=_scan_loop, args=(subnet, ports), daemon=True)
+    _scan_thread.start()
+    return {"status": "started"}
+
+
+@app.post("/dynamic-scan/stop")
+def stop_scan() -> Dict[str, str]:
+    """Stop the running dynamic scan."""
+    global _scan_thread
+    if not _scan_thread or not _scan_thread.is_alive():
+        raise HTTPException(status_code=400, detail="no active scan")
+    _stop_event.set()
+    _scan_thread.join()
+    _scan_thread = None
+    return {"status": "stopped"}
+
+
+@app.get("/dynamic-scan/results")
+def get_results() -> Dict[str, Any]:
+    """Return current scan results."""
+    running = _scan_thread is not None and _scan_thread.is_alive()
+    return {"running": running, "results": _scan_results}

--- a/test/test_dynamic_scan_api.py
+++ b/test/test_dynamic_scan_api.py
@@ -1,0 +1,71 @@
+import time
+from threading import Event
+
+from fastapi.testclient import TestClient
+
+import src.api as api
+
+
+def setup_function():
+    api._scan_thread = None
+    api._stop_event = Event()
+    api._scan_results = []
+
+
+def test_start_and_results(monkeypatch):
+    def fake_scan(subnet, ports):
+        api._stop_event.set()
+        return [{"ip": "192.168.0.2", "ports": [80]}]
+
+    monkeypatch.setattr(api, "scan_hosts", fake_scan)
+    monkeypatch.setattr(api, "_get_subnet", lambda: "192.168.0.0/24")
+    client = TestClient(api.app)
+
+    res = client.post("/dynamic-scan/start", json={})
+    assert res.status_code == 200
+
+    api._scan_thread.join(timeout=1)
+
+    res = client.get("/dynamic-scan/results")
+    assert res.status_code == 200
+    assert res.json() == {
+        "running": False,
+        "results": [{"ip": "192.168.0.2", "ports": [80]}],
+    }
+
+
+def test_start_twice_errors(monkeypatch):
+    def long_scan(subnet, ports):
+        time.sleep(0.2)
+        return []
+
+    monkeypatch.setattr(api, "scan_hosts", long_scan)
+    monkeypatch.setattr(api, "_get_subnet", lambda: "192.168.0.0/24")
+    client = TestClient(api.app)
+
+    client.post("/dynamic-scan/start", json={})
+    res = client.post("/dynamic-scan/start", json={})
+    assert res.status_code == 400
+
+    client.post("/dynamic-scan/stop")
+
+
+def test_stop_without_running():
+    client = TestClient(api.app)
+    res = client.post("/dynamic-scan/stop")
+    assert res.status_code == 400
+
+
+def test_stop(monkeypatch):
+    def long_scan(subnet, ports):
+        time.sleep(0.2)
+        return []
+
+    monkeypatch.setattr(api, "scan_hosts", long_scan)
+    monkeypatch.setattr(api, "_get_subnet", lambda: "192.168.0.0/24")
+    client = TestClient(api.app)
+
+    client.post("/dynamic-scan/start", json={})
+    res = client.post("/dynamic-scan/stop")
+    assert res.status_code == 200
+    assert res.json()["status"] == "stopped"


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for starting/stopping dynamic scans and fetching results
- create Flutter service and page to display dynamic scan results with alerts
- wire dynamic scan page into main UI and include FastAPI deps

## Testing
- `python -m py_compile src/api.py`
- `pytest`
- `dart format lib/dynamic_scan_service.dart lib/dynamic_scan_page.dart lib/main.dart` *(fails: command not found)*
- `flutter format lib/dynamic_scan_service.dart lib/dynamic_scan_page.dart lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c44e98a2c8323a6bc3342b1fd0089