### PR TITLE
Add network map module for host discovery

### DIFF
--- a/network_map.py
+++ b/network_map.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Discover network hosts and output the result as JSON."""
+
+import json
+import sys
+
+from discover_hosts import discover_hosts
+
+
+def main() -> int:
+    """Execute host discovery and print results."""
+    subnet = sys.argv[1] if len(sys.argv) > 1 else None
+    try:
+        hosts = discover_hosts(subnet)
+        print(json.dumps(hosts, ensure_ascii=False))
+        print("Host discovery succeeded", file=sys.stdout)
+        return 0
+    except Exception as exc:
+        print(f"Host discovery failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_network_map.py
+++ b/test/test_network_map.py
@@ -1,0 +1,41 @@
+import json
+import io
+import sys
+import unittest
+from unittest.mock import patch
+
+import network_map
+
+
+class NetworkMapTest(unittest.TestCase):
+    @patch('network_map.discover_hosts')
+    def test_main_success(self, mock_discover):
+        hosts = [{'ip': '1.2.3.4', 'mac': 'aa:bb', 'vendor': 'Vendor'}]
+        mock_discover.return_value = hosts
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with patch('sys.argv', ['network_map.py']), \
+             patch('sys.stdout', stdout), \
+             patch('sys.stderr', stderr):
+            code = network_map.main()
+        self.assertEqual(code, 0)
+        out_lines = stdout.getvalue().strip().splitlines()
+        self.assertEqual(out_lines[0], json.dumps(hosts, ensure_ascii=False))
+        self.assertEqual(out_lines[1], 'Host discovery succeeded')
+        self.assertEqual(stderr.getvalue(), '')
+
+    @patch('network_map.discover_hosts', side_effect=RuntimeError('boom'))
+    def test_main_failure(self, mock_discover):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with patch('sys.argv', ['network_map.py']), \
+             patch('sys.stdout', stdout), \
+             patch('sys.stderr', stderr):
+            code = network_map.main()
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout.getvalue(), '')
+        self.assertIn('Host discovery failed: boom', stderr.getvalue().strip())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `network_map.py` script to run `discover_hosts()`
- output host list in JSON and log success or failure
- test network map behavior for success and failure cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c4bf0a5d88323a2d3236435995b89