### PR TITLE
Add topology builder module for traceroute paths

### DIFF
--- a/test/test_topology_builder.py
+++ b/test/test_topology_builder.py
@@ -1,0 +1,54 @@
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import topology_builder
+
+
+def test_build_paths_traceroute_parsing():
+    hosts = [{"ip": "192.168.1.2"}]
+    traceroute_output = (
+        "traceroute to 192.168.1.2 (192.168.1.2)\n"
+        " 1  192.168.1.1  1 ms\n"
+        " 2  192.168.1.2  2 ms\n"
+    )
+    cp = CompletedProcess(args=[], returncode=0, stdout=traceroute_output, stderr="")
+    with patch("topology_builder.subprocess.run", return_value=cp):
+        data = topology_builder.build_paths(hosts)
+    assert data == {"paths": [{"ip": "192.168.1.2", "path": ["LAN", "Router", "Host"]}]}
+
+
+def test_parse_traceroute_output_extracts_ips():
+    output = (
+        "traceroute to 8.8.8.8\n"
+        " 1  10.0.0.1  1 ms\n"
+        " 2  8.8.8.8  2 ms\n"
+    )
+    hops = topology_builder._parse_traceroute_output(output)
+    assert hops == ["10.0.0.1", "8.8.8.8"]
+
+
+def test_classify_hops_handles_empty_and_multiple():
+    assert topology_builder._classify_hops([]) == ["Host"]
+    hops = ["10.0.0.1", "8.8.8.8"]
+    assert topology_builder._classify_hops(hops) == ["LAN", "Router", "Host"]
+
+
+def test_build_paths_uses_snmp_augmentation():
+    hosts = [{"ip": "192.168.1.2"}]
+    with patch("topology_builder.traceroute", return_value=["192.168.1.1", "192.168.1.2"]), \
+        patch("topology_builder._augment_with_snmp", return_value=["LAN", "Router", "Host", "SNMP"]) as mock_snmp:
+        data = topology_builder.build_paths(hosts, use_snmp=True)
+    mock_snmp.assert_called_once()
+    assert data == {"paths": [{"ip": "192.168.1.2", "path": ["LAN", "Router", "Host", "SNMP"]}]}
+
+
+def test_traceroute_uses_windows_command():
+    with patch("topology_builder.os.name", "nt"), patch(
+        "topology_builder.subprocess.run"
+    ) as mock_run:
+        mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        topology_builder.traceroute("1.1.1.1")
+    mock_run.assert_called_with(
+        ["tracert", "-d", "1.1.1.1"], capture_output=True, text=True, timeout=30
+    )
+

--- a/topology_builder.py
+++ b/topology_builder.py
@@ -1,0 +1,87 @@
+import json
+import os
+import subprocess
+from typing import List, Dict
+
+from discover_hosts import IP_RE
+
+
+def traceroute(ip: str, *, timeout: int = 30) -> List[str]:
+    """Run traceroute/tracert command for given IP and return list of hop IPs."""
+    cmd = ["tracert", "-d", ip] if os.name == "nt" else ["traceroute", "-n", ip]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip())
+    return _parse_traceroute_output(proc.stdout)
+
+
+def _parse_traceroute_output(output: str) -> List[str]:
+    """Extract hop IPs from traceroute command output."""
+    hops: List[str] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if line.lower().startswith("traceroute") or line.lower().startswith("tracing route"):
+            continue
+        for token in line.split():
+            if IP_RE.fullmatch(token) and ("." in token or ":" in token):
+                hops.append(token)
+                break
+    return hops
+
+
+def _classify_hops(hops: List[str]) -> List[str]:
+    """Return list of hop labels such as ['LAN', 'Router', 'Host']."""
+    path: List[str] = ["LAN"] + ["Router"] * len(hops)
+    if path:
+        path[-1] = "Host"
+    return path
+
+
+def _augment_with_snmp(path: List[str], ip: str) -> List[str]:
+    """Augment path information using SNMP/LLDP if pysnmp is available.
+
+    Currently this function acts as a placeholder and returns the path
+    unchanged when SNMP data cannot be retrieved.
+    """
+    try:
+        from pysnmp.hlapi import SnmpEngine  # type: ignore
+    except Exception:
+        return path
+    # Placeholder for SNMP/LLDP augmentation logic
+    return path
+
+
+def build_paths(hosts: List[Dict[str, str]], use_snmp: bool = False) -> Dict[str, List[Dict[str, List[str]]]]:
+    """Build network topology paths for given hosts.
+
+    Args:
+        hosts: List of host dictionaries returned by ``discover_hosts``.
+        use_snmp: When True, attempt to augment hop data using SNMP/LLDP.
+
+    Returns:
+        A dictionary containing a ``paths`` array suitable for JSON
+        serialization.
+    """
+    results = []
+    for host in hosts:
+        ip = host.get("ip")
+        if not ip:
+            continue
+        hops = traceroute(ip)
+        path = _classify_hops(hops)
+        if use_snmp:
+            path = _augment_with_snmp(path, ip)
+        results.append({"ip": ip, "path": path})
+    return {"paths": results}
+
+
+def main() -> None:
+    from discover_hosts import discover_hosts
+
+    hosts = discover_hosts()
+    data = build_paths(hosts)
+    print(json.dumps(data, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refine traceroute output parsing to ignore hop numbers and capture valid hop IPs
- add tests covering IP extraction, hop classification, SNMP augmentation, and Windows command usage

## Testing
- `pytest test/test_topology_builder.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5237a3fc83239b0f01519127c3c2