### PR TITLE
Enhance host discovery with hostname resolution

### DIFF
--- a/discover_hosts.py
+++ b/discover_hosts.py
@@ -1,32 +1,19 @@
 #!/usr/bin/env python3
+"""Host discovery utilities."""
+
 import json
 import sys
-import subprocess
-import xml.etree.ElementTree as ET
-import ipaddress
-import re
-import os
 
-IP_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]+")
-from pathlib import Path
-from urllib.request import urlopen
-from urllib.error import URLError
-import socket
-
-from network_utils import _get_subnet, _run_nmap_scan, _lookup_vendor, SCAN_TIMEOUT
+from network_utils import _get_subnet, _lookup_vendor, _run_nmap_scan
 
 
 def discover_hosts(subnet: str | None = None) -> list[dict[str, str]]:
-    """Return list of discovered hosts with IP, MAC and vendor.
-
-    If ``subnet`` is not provided, the local subnet is determined
-    automatically. ``nmap`` is used for host discovery.
-    """
+    """Return list of discovered hosts with IP, MAC, vendor, and hostname."""
     subnet = subnet or _get_subnet() or "192.168.1.0/24"
     hosts = _run_nmap_scan(subnet)
-    for h in hosts:
-        if not h.get("vendor"):
-            h["vendor"] = _lookup_vendor(h.get("mac", ""))
+    for host in hosts:
+        if not host.get("vendor"):
+            host["vendor"] = _lookup_vendor(host.get("mac", ""))
     return hosts
 
 
@@ -35,145 +22,8 @@ def get_all_ips(subnet: str | None = None) -> list[str]:
     return [h["ip"] for h in discover_hosts(subnet)]
 
 
-def _get_subnet():
-    if os.name == "nt":
-        try:
-            proc = subprocess.run(["ipconfig"], capture_output=True, text=True)
-            if proc.returncode == 0:
-                ip = None
-                mask = None
-                for line in proc.stdout.splitlines():
-                    if "IPv4 Address" in line or line.strip().startswith("IPv4"):
-                        parts = line.split(":")
-                        if len(parts) > 1:
-                            ip = parts[1].strip()
-                    elif "Subnet Mask" in line:
-                        parts = line.split(":")
-                        if len(parts) > 1:
-                            mask = parts[1].strip()
-                    if ip and mask:
-                        break
-                if ip and mask:
-                    try:
-                        network = ipaddress.IPv4Network(f"{ip}/{mask}", strict=False)
-                        return str(network)
-                    except Exception:
-                        pass
-        except Exception:
-            pass
-    elif sys.platform == "darwin":
-        try:
-            proc = subprocess.run(["ifconfig"], capture_output=True, text=True)
-            if proc.returncode == 0:
-                for line in proc.stdout.splitlines():
-                    line = line.strip()
-                    m = re.search(
-                        r"inet (\d+\.\d+\.\d+\.\d+) netmask (0x[0-9a-fA-F]+)", line
-                    )
-                    if m and not m.group(1).startswith("127."):
-                        ip = m.group(1)
-                        mask_hex = m.group(2)
-                        try:
-                            mask_addr = ipaddress.IPv4Address(int(mask_hex, 16))
-                            network = ipaddress.IPv4Network(
-                                f"{ip}/{mask_addr}", strict=False
-                            )
-                            return str(network)
-                        except Exception:
-                            continue
-        except Exception:
-            pass
-    else:
-        try:
-            proc = subprocess.run(["ip", "addr"], capture_output=True, text=True)
-            if proc.returncode == 0:
-                inet = None
-                mask = None
-                for line in proc.stdout.splitlines():
-                    line = line.strip()
-                    m = re.match(r"inet (\d+\.\d+\.\d+\.\d+)/(\d+)", line)
-                    if m and not m.group(1).startswith("127."):
-                        inet = m.group(1)
-                        masklen = int(m.group(2))
-                        network = ipaddress.IPv4Network(
-                            f"{inet}/{masklen}", strict=False
-                        )
-                        return str(network)
-        except Exception:
-            pass
-    return None
-
-
-SCAN_TIMEOUT = 60
-
-
-def _run_nmap_scan(subnet, *, timeout: int = SCAN_TIMEOUT):
-    cmd = ["nmap"]
-    try:
-        if ipaddress.ip_network(subnet, strict=False).version == 6:
-            cmd.append("-6")
-    except Exception:
-        if ":" in subnet:
-            cmd.append("-6")
-    cmd += ["-sn", subnet, "-oX", "-"]
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("nmap host discovery timed out")
-    if proc.returncode != 0:
-        raise RuntimeError(proc.stderr.strip())
-    root = ET.fromstring(proc.stdout)
-    results = []
-    for host in root.findall("host"):
-        ip = None
-        mac = ""
-        vendor = ""
-        for addr in host.findall("address"):
-            if addr.get("addrtype") in ("ipv4", "ipv6"):
-                ip = addr.get("addr")
-            elif addr.get("addrtype") == "mac":
-                mac = addr.get("addr")
-                vendor = addr.get("vendor", "")
-        if ip:
-            results.append({"ip": ip, "mac": mac, "vendor": vendor})
-    return results
-
-
-def _lookup_vendor(mac):
-    prefix = mac.upper().replace(":", "")[:6]
-
-    if prefix in _VENDOR_CACHE:
-        return _VENDOR_CACHE[prefix]
-
-    db_path = Path("oui.txt")
-    if db_path.exists():
-        try:
-            with db_path.open("r", encoding="utf-8", errors="ignore") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    if line.upper().startswith(prefix):
-                        vendor = line[6:].strip()
-                        _VENDOR_CACHE[prefix] = vendor
-                        return vendor
-        except Exception:
-            pass
-
-    try:
-        # Limit HTTP request time so vendor lookup does not block scanning
-        with urlopen(f"https://api.macvendors.com/{mac}", timeout=3) as resp:
-            vendor = resp.read().decode("utf-8")
-            _VENDOR_CACHE[prefix] = vendor
-            return vendor
-    except (URLError, socket.timeout):
-        _VENDOR_CACHE[prefix] = ""
-        return ""
-
-def main():
-    subnet = None
-    if len(sys.argv) > 1:
-        subnet = sys.argv[1]
+def main() -> None:
+    subnet = sys.argv[1] if len(sys.argv) > 1 else None
     hosts = discover_hosts(subnet)
     print(json.dumps({"hosts": hosts}, ensure_ascii=False))
 

--- a/test/test_discover_hosts_ipv6.py
+++ b/test/test_discover_hosts_ipv6.py
@@ -2,20 +2,24 @@ import unittest
 from unittest.mock import patch, MagicMock
 import network_utils
 
+
 class DiscoverHostsIPv6Test(unittest.TestCase):
     def test_run_nmap_scan_ipv6(self):
-        xml = """<nmaprun><host><address addr='fe80::1' addrtype='ipv6'/><address addr='00:11:22:33:44:55' addrtype='mac' vendor='ACME'/></host></nmaprun>"""
-        with patch('subprocess.run') as m:
-            m.return_value = MagicMock(returncode=0, stdout=xml)
-            res = network_utils._run_nmap_scan('fe80::/64')
-            m.assert_called_with(
-                ['nmap', '-6', '-sn', 'fe80::/64', '-oX', '-'],
-                capture_output=True,
-                text=True,
-                timeout=network_utils.SCAN_TIMEOUT,
-            )
-            self.assertEqual(res[0]['ip'], 'fe80::1')
-            self.assertEqual(res[0]['mac'], '00:11:22:33:44:55')
+        xml = "<nmaprun><host><address addr='fe80::1' addrtype='ipv6'/><address addr='00:11:22:33:44:55' addrtype='mac' vendor='ACME'/></host></nmaprun>"
+        with patch('network_utils.shutil.which', return_value=None):
+            with patch('subprocess.run') as m:
+                m.return_value = MagicMock(returncode=0, stdout=xml)
+                res = network_utils._run_nmap_scan('fe80::/64')
+                m.assert_called_with(
+                    ['nmap', '-6', '-R', '-sn', 'fe80::/64', '-oX', '-'],
+                    capture_output=True,
+                    text=True,
+                    timeout=network_utils.SCAN_TIMEOUT,
+                )
+                self.assertEqual(res[0]['ip'], 'fe80::1')
+                self.assertEqual(res[0]['mac'], '00:11:22:33:44:55')
+
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- consolidate host discovery helpers in `network_utils` and simplify `discover_hosts` wrapper
- ensure nmap host discovery performs reverse DNS lookups and fills missing hostnames via `nbtscan`/`avahi-resolve`
- test hostname detection and verify IPv6 scans include `-R`

## Testing
- `pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c50066a94832381397869ba76476c