### PR TITLE
Build topology tree from path hierarchy

### DIFF
--- a/generate_topology.py
+++ b/generate_topology.py
@@ -25,14 +25,33 @@ def build_graph(data: Any) -> Graph:
     # be tapped in the Flutter UI.
     g.attr("node", shape="ellipse")
     g.node("LAN")
+
     for host in hosts:
         ip = host.get("ip") or host.get("device") or "unknown"
-        label = ip
+        label_parts = [ip]
+        hostname = host.get("hostname")
+        if hostname:
+            label_parts.append(hostname)
         vendor = host.get("vendor")
         if vendor:
-            label = f"{ip}\n{vendor}"
+            label_parts.append(vendor)
+        label = "\n".join(label_parts)
         g.node(ip, label=label)
-        g.edge("LAN", ip)
+
+        paths = host.get("paths") or []
+        if paths:
+            for path in paths:
+                prev = None
+                for node in path:
+                    g.node(node)
+                    if prev is not None:
+                        g.edge(prev, node)
+                    prev = node
+                if not path or path[-1] != ip:
+                    if prev is not None:
+                        g.edge(prev, ip)
+        else:
+            g.edge("LAN", ip)
     return g
 
 

--- a/test/test_generate_topology.py
+++ b/test/test_generate_topology.py
@@ -17,6 +17,46 @@ class GenerateTopologyTest(unittest.TestCase):
         self.assertIn("192.168.1.2", src)
         self.assertIn('LAN -- "192.168.1.2"', src)
 
+    def test_build_graph_with_paths(self):
+        data = {
+            "hosts": [
+                {
+                    "ip": "192.168.1.3",
+                    "hostname": "Host",
+                    "vendor": "V",
+                    "paths": [["LAN", "Switch1"]],
+                }
+            ]
+        }
+        g = generate_topology.build_graph(data)
+        src = g.source
+        self.assertIn('LAN -- Switch1', src)
+        self.assertIn('Switch1 -- "192.168.1.3"', src)
+        self.assertIn('label="192.168.1.3\nHost\nV"', src)
+
+    def test_build_graph_multiple_paths_and_shape(self):
+        data = {
+            "hosts": [
+                {
+                    "ip": "192.168.1.4",
+                    "hostname": "Host2",
+                    "vendor": "Vendor2",
+                    "paths": [
+                        ["LAN", "SwitchA", "RouterA"],
+                        ["LAN", "SwitchB"],
+                    ],
+                }
+            ]
+        }
+        g = generate_topology.build_graph(data)
+        src = g.source
+        self.assertIn('LAN -- SwitchA', src)
+        self.assertIn('SwitchA -- RouterA', src)
+        self.assertIn('RouterA -- "192.168.1.4"', src)
+        self.assertIn('LAN -- SwitchB', src)
+        self.assertIn('SwitchB -- "192.168.1.4"', src)
+        self.assertIn('node [shape=ellipse]', src)
+
     def test_save_graph_dot(self):
         g = generate_topology.Graph("test")
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- Generate graphviz topology using provided path chains
- Label nodes with hostname and vendor while keeping ellipse shapes for Flutter
- Test hierarchical topology paths and multiple path branches

## Testing
- `pytest test/test_generate_topology.py`


------
https://chatgpt.com/codex/tasks/task_e_689e06a01f4483238fc21a979e068d21