### PR TITLE
Add vendor lookup and hostname resolution using nbtscan

### DIFF
--- a/network_utils.py
+++ b/network_utils.py
@@ -158,6 +158,10 @@ def _run_nmap_scan(subnet: str, *, timeout: int = SCAN_TIMEOUT):
                             h["hostname"] = name
             except Exception:
                 pass
+
+    for h in results:
+        if h.get("mac") and not h.get("vendor"):
+            h["vendor"] = _lookup_vendor(h["mac"])
     return results
 
 


### PR DESCRIPTION
## Summary
- resolve hostnames with nbtscan and avahi-resolve when nmap lacks them
- fetch vendor names via online API when OUI database is missing
- test host discovery includes hostname and vendor fields
- add unit test ensuring `_run_nmap_scan` invokes vendor lookup for MAC addresses lacking vendor info

## Testing
- `pytest test/test_discover_hosts.py test/test_discover_hosts_ipv6.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3229b51b48323b18e16ef613d4341