### PR TITLE
refactor: isolate network map output

### DIFF
--- a/network_map.py
+++ b/network_map.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Discover network hosts and output the result as JSON.
 
-This module calls ``discover_hosts`` to obtain a list of hosts and prints the
-list in JSON format. A success message is written to stdout while failures are
-reported to stderr.
+This module calls :func:`discover_hosts` to obtain a list of hosts and prints
+the list in JSON format to ``stdout``.  Failures are written to ``stderr`` and
+result in a non-zero exit code.
 """
 
 from __future__ import annotations
@@ -56,10 +56,9 @@ def main() -> int:
     try:
         hosts = discover_hosts(args.subnet)
         print(json.dumps({"hosts": hosts}, ensure_ascii=False))
-        logger.info("Host discovery succeeded")
         return 0
     except Exception as exc:  # pragma: no cover - required for test coverage
-        logger.error("Host discovery failed: %s", exc)
+        logger.error("%s", exc)
         return 1
 
 


### PR DESCRIPTION
## Summary
- ensure network_map prints only JSON host list to stdout
- log only error messages on failure
- test success and failure of network_map via mocks
- verify logging configuration routes info to stdout and errors to stderr

## Testing
- `pytest test/test_network_map.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32296e80c83239fb42e6eda65674a